### PR TITLE
Add root SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: gitlab-cli-skills
+description: Use when working with GitLab CLI (glab) commands across auth, CI/CD, merge requests, issues, releases, repos, and related operations. Routes to specific glab-* sub-skills.
+---
+
+# GitLab CLI Skills
+
+This skill routes to specific `glab-*` sub-skills for GitLab CLI usage.
+
+## Available Skills
+
+- `glab-auth`
+- `glab-alias`
+- `glab-api`
+- `glab-attestation`
+- `glab-changelog`
+- `glab-check-update`
+- `glab-ci`
+- `glab-cluster`
+- `glab-completion`
+- `glab-config`
+- `glab-deploy-key`
+- `glab-duo`
+- `glab-gpg-key`
+- `glab-help`
+- `glab-incident`
+- `glab-issue`
+- `glab-iteration`
+- `glab-job`
+- `glab-label`
+- `glab-mcp`
+- `glab-milestone`
+- `glab-mr`
+- `glab-opentofu`
+- `glab-release`
+- `glab-repo`
+- `glab-schedule`
+- `glab-securefile`
+- `glab-snippet`
+- `glab-ssh-key`
+- `glab-stack`
+- `glab-token`
+- `glab-user`
+- `glab-variable`
+- `glab-version`


### PR DESCRIPTION
Adds a root SKILL.md that routes to all available glab-* skills.

Closes #5.
