### PR TITLE
Exclude .gitattributes from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 LICENSE export-ignore
 .DS_Store export-ignore
 .gitignore export-ignore
+.gitattributes export-ignore
 RELEASE_NOTES_BEST_PRACTICE.md export-ignore


### PR DESCRIPTION
Updates .gitattributes to export-ignore itself in release source archives.

Closes #7.
