### PR TITLE
Fix GraphQL formatting in glab-api examples

### DIFF
--- a/glab-api/SKILL.md
+++ b/glab-api/SKILL.md
@@ -82,42 +82,43 @@ description: Use when working with glab api commands.
     $ glab api issues --paginate --output ndjson                                    
     $ glab api issues --paginate --output ndjson | jq 'select(.state == "opened")'  
     $ glab api graphql -f query="query { currentUser { username } }"                
-    $ glab api graphql -f query='                                                   
-    query {                                                                         
-    project(fullPath: "gitlab-org/gitlab-docs") {                                   
-    name                                                                            
-    forksCount                                                                      
-    statistics {                                                                    
-    wikiSize                                                                        
-    }                                                                               
-    issuesEnabled                                                                   
-    boards {                                                                        
-    nodes {                                                                         
-    id                                                                              
-    name                                                                            
-    }                                                                               
-    }                                                                               
-    }                                                                               
-    }                                                                               
+    $ glab api graphql -f query='
+    query {
+      project(fullPath: "gitlab-org/gitlab-docs") {
+        name
+        forksCount
+        statistics {
+          wikiSize
+        }
+        issuesEnabled
+        boards {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+    }
     '                                                                               
                                                                                     
-    $ glab api graphql --paginate -f query='                                        
-    query($endCursor: String) {                                                     
-    project(fullPath: "gitlab-org/graphql-sandbox") {                               
-    name                                                                            
-    issues(first: 2, after: $endCursor) {                                           
-    edges {                                                                         
-    node {                                                                          
-    title                                                                           
-    }                                                                               
-    }                                                                               
-    pageInfo {                                                                      
-    endCursor                                                                       
-    hasNextPage                                                                     
-    }                                                                               
-    }                                                                               
-    }                                                                               
-    }'                                                                              
+    $ glab api graphql --paginate -f query='
+    query($endCursor: String) {
+      project(fullPath: "gitlab-org/graphql-sandbox") {
+        name
+        issues(first: 2, after: $endCursor) {
+          edges {
+            node {
+              title
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }
+    '                                                                              
          
   FLAGS  
          


### PR DESCRIPTION
Fixes #9

## Changes

Properly formatted GraphQL queries in  with consistent 2-space indentation per nesting level.

### Before
```
query {
project(fullPath: "gitlab-org/gitlab-docs") {
name
forksCount
```

### After
```
query {
  project(fullPath: "gitlab-org/gitlab-docs") {
    name
    forksCount
```

## Impact

- **Improved readability** for both humans and bots
- **No functional changes** — queries remain identical (whitespace-only)
- **Files changed:** 1 (glab-api/SKILL.md)
- **Lines changed:** 35 insertions(+), 34 deletions(-)

## Testing

- [x] Verified GraphQL syntax remains valid
- [x] Confirmed indentation is consistent (2 spaces per level)
- [x] Checked no other .md files contain unformatted GraphQL/JSON

## Scope

Searched all SKILL.md and commands.md files in the repo. Only  contained GraphQL queries that needed formatting. No unformatted JSON payloads were found.