### PR TITLE
Fix ClawHub security flag: Add requirements metadata

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: gitlab-cli-skills
 description: Comprehensive GitLab CLI (glab) command reference and workflows for all GitLab operations via terminal. Use when user mentions GitLab CLI, glab commands, GitLab automation, MR/issue management via CLI, CI/CD pipeline commands, repo operations, authentication setup, or any GitLab terminal operations. Routes to specialized sub-skills for auth, CI, MRs, issues, releases, repos, and 30+ other glab commands. Triggers on glab, GitLab CLI, GitLab commands, GitLab terminal, GitLab automation.
+requirements:
+  binaries:
+    - glab
+  binaries_optional:
+    - cosign
+  notes: |
+    Requires GitLab authentication via 'glab auth login' (stores token in ~/.config/glab-cli/config.yml).
+    Some features may access sensitive files: SSH keys (~/.ssh/id_rsa for DPoP), Docker config (~/.docker/config.json for registry auth).
+    Review auth workflows and script contents before autonomous use.
 ---
 
 # GitLab CLI Skills


### PR DESCRIPTION
## Problem

ClawHub security scanner flagged gitlab-cli-skills as "Suspicious (Medium Confidence)" because the registry metadata declared no required binaries or environment variables, while the actual code clearly needs them and accesses sensitive files.

**ClawHub scan:** https://clawhub.ai/vince-winkintel/gitlab-cli-skills

**Scanner concerns:**
1. ✓ Purpose aligns with GitLab CLI reference
2. ❌ **Instruction scope** - Runtime docs reference reading tokens/keys (`~/.ssh/id_rsa`, `~/.docker/config.json`) but manifest doesn't declare these
3. ❌ **Credentials** - Docs reference PATs, CI tokens, SSH keys, Docker creds, but no declared requirements
4. ✓ Install mechanism is safe (instruction-only)
5. ✓ Persistence/privilege normal for CLI tool

## Changes

Added `requirements` section to root `SKILL.md` YAML frontmatter:

**Required:**
- `glab` binary

**Optional:**
- `cosign` binary (for attestation features)

**Security notes:**
- Documents GitLab authentication requirement (`glab auth login`)
- Discloses potential sensitive file access (SSH keys, Docker config)
- Advises review before autonomous use

## Impact

✅ Resolves metadata transparency gap  
✅ Users will know `glab` binary is required  
✅ Security notes disclose sensitive file access patterns  
✅ ClawHub security scan should pass after republish  
✅ No functional code changes (metadata only)

## Testing

- [x] Verified YAML frontmatter syntax
- [x] Confirmed requirements match actual script/workflow needs
- [x] Security notes address scanner concerns
- [x] No breaking changes to skill functionality

Fixes #21