### PR TITLE
Add inline comment automation for MR code reviews

### DIFF
--- a/scripts/README-inline-comments.md
+++ b/scripts/README-inline-comments.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `glab-add-inline-comment.sh` script enables posting inline code review comments to GitLab merge requests at specific file lines. This is more effective than general MR comments because developers can see feedback directly in context without hunting through code.
+The `add-inline-comment.sh` script enables posting inline code review comments to GitLab merge requests at specific file lines. This is more effective than general MR comments because developers can see feedback directly in context without hunting through code.
 
 ## Why Use Inline Comments?
 
@@ -21,10 +21,10 @@ The `glab-add-inline-comment.sh` script enables posting inline code review comme
 ```bash
 # The script is already in the gitlab-cli-skills repo
 cd /path/to/gitlab-cli-skills/scripts
-chmod +x glab-add-inline-comment.sh
+chmod +x add-inline-comment.sh
 
 # Optional: Add to PATH for global access
-ln -s $(pwd)/glab-add-inline-comment.sh ~/.local/bin/glab-add-inline-comment
+ln -s $(pwd)/add-inline-comment.sh ~/.local/bin/add-inline-comment
 ```
 
 ## Requirements
@@ -36,7 +36,7 @@ ln -s $(pwd)/glab-add-inline-comment.sh ~/.local/bin/glab-add-inline-comment
 ## Usage
 
 ```bash
-glab-add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
+add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
 ```
 
 ### Parameters
@@ -53,7 +53,7 @@ glab-add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_te
 
 **Simple comment:**
 ```bash
-glab-add-inline-comment.sh \
+add-inline-comment.sh \
   "owner/repo" \
   "42" \
   "src/components/Button.tsx" \
@@ -63,7 +63,7 @@ glab-add-inline-comment.sh \
 
 **Bug report with markdown:**
 ```bash
-glab-add-inline-comment.sh \
+add-inline-comment.sh \
   "owner/repo" \
   "42" \
   "src/utils/validator.js" \
@@ -77,9 +77,9 @@ glab-add-inline-comment.sh \
 REPO="owner/repo"
 MR_IID="42"
 
-glab-add-inline-comment.sh "$REPO" "$MR_IID" "src/api.js" 15 "Add error handling"
-glab-add-inline-comment.sh "$REPO" "$MR_IID" "src/api.js" 22 "Use async/await instead of .then()"
-glab-add-inline-comment.sh "$REPO" "$MR_IID" "src/types.ts" 8 "Missing JSDoc comment"
+add-inline-comment.sh "$REPO" "$MR_IID" "src/api.js" 15 "Add error handling"
+add-inline-comment.sh "$REPO" "$MR_IID" "src/api.js" 22 "Use async/await instead of .then()"
+add-inline-comment.sh "$REPO" "$MR_IID" "src/types.ts" 8 "Missing JSDoc comment"
 ```
 
 ## How It Works
@@ -191,7 +191,7 @@ if echo "$DIFF" | grep -q "console.log"; then
     LINE=$(echo "$DIFF" | grep -n "console.log" | head -1 | cut -d: -f1)
     FILE=$(echo "$DIFF" | grep -B20 "console.log" | grep "^+++" | head -1 | cut -d/ -f2-)
     
-    glab-add-inline-comment.sh "$REPO" "$MR_IID" "$FILE" "$LINE" \
+    add-inline-comment.sh "$REPO" "$MR_IID" "$FILE" "$LINE" \
         "⚠️ Remove console.log before merging"
 fi
 
@@ -216,7 +216,7 @@ while IFS=: read -r file line message; do
     # Remove absolute path prefix
     rel_path="${file#/absolute/path/to/repo/}"
     
-    glab-add-inline-comment.sh "$REPO" "$MR_IID" "$rel_path" "$line" "ESLint: $message"
+    add-inline-comment.sh "$REPO" "$MR_IID" "$rel_path" "$line" "ESLint: $message"
 done
 ```
 
@@ -254,7 +254,7 @@ Test on a personal repo before using on production MRs:
 glab mr create --title "Test MR" --repo owner/test-repo
 
 # Post test comment
-./glab-add-inline-comment.sh \
+./add-inline-comment.sh \
   "owner/test-repo" \
   "1" \
   "README.md" \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,16 +56,16 @@ Debug CI failures by showing failed job logs.
 2. Shows last 50 lines of each failed job's log
 3. Provides next steps for debugging
 
-### `glab-add-inline-comment.sh`
+### `add-inline-comment.sh`
 
 Post inline code review comments at specific line numbers in MR diffs.
 
 ```bash
-./scripts/glab-add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
+./scripts/add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
 
 # Examples
-./scripts/glab-add-inline-comment.sh owner/repo 42 "src/main.js" 100 "Bug: Add null check"
-./scripts/glab-add-inline-comment.sh owner/repo 42 "lib/util.py" 25 "**Performance**: Use dict comprehension"
+./scripts/add-inline-comment.sh owner/repo 42 "src/main.js" 100 "Bug: Add null check"
+./scripts/add-inline-comment.sh owner/repo 42 "lib/util.py" 25 "**Performance**: Use dict comprehension"
 ```
 
 **What it does:**

--- a/scripts/add-inline-comment.sh
+++ b/scripts/add-inline-comment.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# glab-add-inline-comment.sh
+# add-inline-comment.sh
 # Post inline code review comments to GitLab MRs at specific line numbers
 # Part of: gitlab-cli-skills
 # 
-# Usage: glab-add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
-# Example: glab-add-inline-comment.sh owner/repo 42 "src/File.js" 100 "Bug: This needs fixing"
+# Usage: add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
+# Example: add-inline-comment.sh owner/repo 42 "src/File.js" 100 "Bug: This needs fixing"
 
 set -e
 


### PR DESCRIPTION
## Summary
Adds `glab-add-inline-comment.sh` script to enable posting inline code review comments at specific line numbers in GitLab merge requests.

Closes #26

## Changes

### New Files
1. **`scripts/glab-add-inline-comment.sh`** - Main automation script
   - Posts inline comments via GitLab Discussions API
   - Auto-extracts token from glab config
   - Auto-fetches MR metadata (project ID, SHAs)
   - Validates inline placement (checks for DiffNote type)
   - Returns direct URL to comment

2. **`scripts/README-inline-comments.md`** - Comprehensive documentation
   - Installation instructions
   - Usage examples (simple, advanced, batch reviews)
   - How it works (technical details)
   - Troubleshooting guide
   - Integration examples (automated review workflows)

3. **`scripts/README.md`** - Updated to list new script

## Usage

```bash
glab-add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
```

**Example:**
```bash
glab-add-inline-comment.sh "owner/repo" 42 "src/main.js" 100 "Bug: Add null check here"
```

## Why This Matters

**Problem:** GitLab's native `glab mr note` only creates general MR comments. Reviewers want to comment on specific lines, but there's no built-in command.

**Solution:** This script uses GitLab's Discussions API with proper position data (file path, line number, commit SHAs) to post inline comments.

**Benefits:**
- 📍 **Contextualized feedback** - Comments appear at exact line locations
- ⏱️ **Saves time** - No manual clicking in GitLab UI
- 🤖 **Enables automation** - Can be integrated into review workflows
- ✅ **Better UX** - Developers see feedback in context

## Testing

Tested successfully on real MRs:
- Posted inline comments at specific line numbers
- Comments appear inline in GitLab UI at exact locations
- Note type: `DiffNote` (confirms inline placement)
- Full error handling works correctly

## Technical Details

**Why curl instead of glab api?**
- GitLab API requires `position` as a nested JSON object
- `glab api --field` sends flat parameters, not nested objects
- Must use curl with proper JSON Content-Type header

**API Endpoint:**
```
POST /projects/:id/merge_requests/:merge_request_iid/discussions
```

**Position fields required:**
- `base_sha` - Target branch commit
- `head_sha` - Source branch commit
- `start_sha` - Merge base commit
- `new_path` - File path relative to repo root
- `new_line` - Line number in NEW version

## Requirements

- glab CLI configured and authenticated
- jq for JSON parsing
- curl for API calls

## Documentation

Full documentation in `scripts/README-inline-comments.md` includes:
- Installation steps
- Usage examples
- How it works
- Troubleshooting
- Integration with code review workflows
- API reference

## Future Enhancements

Possible additions (not in this PR):
- Support for self-hosted GitLab instances
- Batch mode (read from file)
- Line range support (multi-line comments)
- Integration with `glab-mr` review workflow