### PR TITLE
feat: Update skills for glab v1.86.0 and v1.87.0

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -57,12 +57,14 @@ This skill routes to specialized sub-skills by GitLab domain:
 - `glab-schedule` - Scheduled pipelines and cron jobs
 - `glab-variable` - CI/CD variables and secrets
 - `glab-securefile` - Secure files for pipelines
+- `glab-runner` - Runner management: list, pause, delete (added v1.87.0)
 - `glab-runner-controller` - Runner controller and token management (EXPERIMENTAL, admin-only)
 
 **Collaboration:**
 - `glab-user` - User profiles and information
 - `glab-snippet` - Code snippets (GitLab gists)
 - `glab-incident` - Incident management
+- `glab-workitems` - Work items: tasks, OKRs, key results, next-gen epics (added v1.87.0)
 
 **Advanced:**
 - `glab-api` - Direct REST API calls

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -50,6 +50,43 @@ description: Manage glab CLI configuration settings including defaults, preferen
 glab config --help
 ```
 
+## v1.86.0 Changes
+
+### Per-host HTTPS proxy configuration
+As of v1.86.0, you can configure an HTTPS proxy on a per-host basis. This is useful when different GitLab instances (e.g. gitlab.com vs a self-hosted instance) require different proxy settings.
+
+```bash
+# Set HTTPS proxy for a specific host
+glab config set https_proxy "http://proxy.example.com:8080" --host gitlab.mycompany.com
+
+# Set globally (applies to all hosts without a specific override)
+glab config set https_proxy "http://proxy.example.com:8080" --global
+
+# Verify
+glab config get https_proxy --host gitlab.mycompany.com
+```
+
+**Precedence:** Per-host config overrides global config. Global config overrides the `HTTPS_PROXY` / `https_proxy` environment variables.
+
+## Common Settings
+
+```bash
+# View current config
+glab config get --global
+
+# Set default editor
+glab config set editor vim --global
+
+# Set pager
+glab config set glab_pager "less -R" --global
+
+# Disable update checks
+glab config set check_update false --global
+
+# Set default host
+glab config set host https://gitlab.mycompany.com --global
+```
+
 ## Subcommands
 
 See [references/commands.md](references/commands.md) for full `--help` output.

--- a/glab-duo/SKILL.md
+++ b/glab-duo/SKILL.md
@@ -35,6 +35,21 @@ description: Interact with GitLab Duo AI assistant for code suggestions and chat
 glab duo --help
 ```
 
+## v1.87.0 Changes
+
+### Binary download management
+As of v1.87.0, `glab duo` includes a CLI binary download management command for installing and updating the GitLab Duo AI binary.
+
+```bash
+# Download/update the Duo CLI binary
+glab duo update
+
+# Check current Duo binary version
+glab duo --version
+```
+
+**When to use:** Run `glab duo update` after upgrading glab to ensure the Duo AI binary matches your CLI version. If `glab duo ask` stops working after a glab upgrade, this is usually the fix.
+
 ## Subcommands
 
 See [references/commands.md](references/commands.md) for full `--help` output.

--- a/glab-mcp/SKILL.md
+++ b/glab-mcp/SKILL.md
@@ -44,6 +44,14 @@ description: Work with Model Context Protocol (MCP) server for AI assistant inte
 glab mcp --help
 ```
 
+## v1.86.0 Changes
+
+### Auto-enabled JSON output
+As of v1.86.0, `glab mcp serve` automatically enables JSON output format when running — no manual flag needed. This improves parsing reliability for AI assistants consuming the MCP server's tool responses.
+
+### Unannotated commands excluded
+Commands that lack MCP annotations are no longer registered as MCP tools. This means only explicitly supported commands are exposed to AI assistants, reducing noise and improving reliability. If a GitLab operation you expect isn't available as an MCP tool, it may lack MCP annotations in the current release.
+
 ## Subcommands
 
 See [references/commands.md](references/commands.md) for full `--help` output.

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -132,6 +132,55 @@ glab mr merge 123
 **Automation:**
 - Script: `scripts/mr-review-workflow.sh` for automated review + test workflow
 
+## v1.87.0 Changes: New `glab mr list` Flags
+
+The following flags were added to `glab mr list` in v1.87.0:
+
+```bash
+# Filter by author
+glab mr list --author <username>
+
+# Filter by source or target branch
+glab mr list --source-branch feature/my-branch
+glab mr list --target-branch main
+
+# Filter by draft status
+glab mr list --draft
+glab mr list --not-draft
+
+# Filter by label or exclude label
+glab mr list --label bugfix
+glab mr list --not-label wip
+
+# Order and sort
+glab mr list --order updated_at --sort desc
+glab mr list --order merged_at --sort asc
+
+# Date range filtering
+glab mr list --created-after 2026-01-01
+glab mr list --created-before 2026-03-01
+
+# Search in title/description
+glab mr list --search "login fix"
+
+# Full flag reference (all available flags)
+glab mr list \
+  --assignee @me \
+  --author vince \
+  --reviewer @me \
+  --label bugfix \
+  --not-label wip \
+  --source-branch feature/x \
+  --target-branch main \
+  --milestone "v2.0" \
+  --draft \
+  --state opened \
+  --order updated_at \
+  --sort desc \
+  --search "auth" \
+  --created-after 2026-01-01
+```
+
 ## Command reference
 
 For complete command documentation and all flags, see [references/commands.md](references/commands.md).

--- a/glab-runner-controller/SKILL.md
+++ b/glab-runner-controller/SKILL.md
@@ -202,11 +202,48 @@ Do you need the controller active?
 - Use `--per-page` to adjust (max varies by instance)
 - Use `--page` to navigate through results
 
+## v1.87.0 Changes: Runner Scope Subcommands
+
+As of v1.87.0, runner controllers support a `runner` scope for managing the runners associated with a controller.
+
+### List Runners in Scope
+
+```bash
+# List all runners managed by controller 42
+glab runner-controller runner list 42
+
+# Output as JSON
+glab runner-controller runner list 42 --output json
+
+# Paginate
+glab runner-controller runner list 42 --page 2 --per-page 50
+```
+
+### Add Runner to Scope
+
+```bash
+# Add runner to controller 42's scope
+glab runner-controller runner create 42 --runner-id <runner-id>
+```
+
+### Remove Runner from Scope
+
+```bash
+# Remove runner from controller 42's scope (with confirmation)
+glab runner-controller runner delete 42 <runner-id>
+
+# Remove without confirmation
+glab runner-controller runner delete 42 <runner-id> --force
+```
+
+**Use case:** Runner scope management lets you explicitly define which runners are orchestrated by a given controller, giving you fine-grained control over runner assignment in multi-controller environments.
+
 ## Related Skills
 
 **CI/CD & Runners:**
 - `glab-ci` - View and manage CI/CD pipelines and jobs
 - `glab-job` - Retry, cancel, view logs for individual jobs
+- `glab-runner` - Manage individual runners (list, pause, delete) — added v1.87.0
 
 **Repository Management:**
 - `glab-repo` - Manage repositories (runner controllers are instance-level)

--- a/glab-runner/SKILL.md
+++ b/glab-runner/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: glab-runner
+description: Manage GitLab CI/CD runners — list, pause, and delete runners at project, group, or instance level. Use when viewing runner status, temporarily pausing a runner, or removing a decommissioned runner. Triggers on runner, glab runner, list runners, pause runner, delete runner, CI runner.
+---
+
+# glab runner
+
+Manage GitLab CI/CD runners from the command line.
+
+> **Added in glab v1.87.0**
+
+## Quick Start
+
+```bash
+# List runners for current project
+glab runner list
+
+# Pause a runner
+glab runner pause <runner-id>
+
+# Delete a runner
+glab runner delete <runner-id>
+```
+
+## Common Workflows
+
+### List Runners
+
+```bash
+# List all runners for current project
+glab runner list
+
+# List for a specific project
+glab runner list --repo owner/project
+
+# List all runners (instance-level, admin only)
+glab runner list --all
+
+# Output as JSON
+glab runner list --output json
+
+# Paginate
+glab runner list --page 2 --per-page 50
+```
+
+**Sample JSON output parsing:**
+```bash
+# Find all paused runners
+glab runner list --output json | python3 -c "
+import sys, json
+runners = json.load(sys.stdin)
+paused = [r for r in runners if r.get('paused')]
+for r in paused:
+    print(f\"{r['id']}: {r.get('description','(no description)')} — {r.get('status')}\")
+"
+```
+
+### Pause a Runner
+
+Pausing a runner prevents it from picking up new jobs without removing it.
+
+```bash
+# Pause runner 123
+glab runner pause 123
+
+# Pause in a specific project context
+glab runner pause 123 --repo owner/project
+```
+
+**When to pause:**
+- Maintenance window (updates, reboots)
+- Investigating a failing runner
+- Temporarily reducing runner capacity
+- Before decommissioning (verify no jobs are running first)
+
+### Delete a Runner
+
+```bash
+# Delete with confirmation prompt
+glab runner delete 123
+
+# Delete without confirmation
+glab runner delete 123 --force
+
+# Delete in a specific project context
+glab runner delete 123 --repo owner/project
+```
+
+**⚠️ Deletion is permanent.** Pause first if unsure.
+
+## Decision Tree: Pause vs Delete
+
+```
+Do you need the runner gone permanently?
+├─ No → Pause it (recoverable)
+└─ Yes → Is it actively running jobs?
+          ├─ Yes → Pause first, wait for jobs to finish, then delete
+          └─ No → Delete with --force
+```
+
+## Runner Status Reference
+
+| Status | Meaning |
+|---|---|
+| `online` | Connected and ready to accept jobs |
+| `offline` | Not connected (check runner process) |
+| `paused` | Connected but not accepting new jobs |
+| `stale` | No contact in the last 3 months |
+
+## Troubleshooting
+
+**"runner: command not found":**
+- Requires glab v1.87.0+. Check with `glab version`.
+
+**"Permission denied" on instance-level runners:**
+- Instance-level runner management requires GitLab admin privileges.
+- Project runners can be managed by project maintainers.
+
+**Runner won't pause:**
+- Verify runner ID with `glab runner list`.
+- Check permissions (must be at least Maintainer on the project).
+
+**Runner stuck "online" after pause:**
+- The runner process is still running on the host — it just won't accept new jobs.
+- This is expected. To fully stop, SSH into the runner host and stop the process.
+
+**Cannot delete runner:**
+- Runner may be shared/group-level (requires higher privileges).
+- Check if runner is assigned to multiple projects; removing from one project may require project-level deletion vs instance-level.
+
+## Related Skills
+
+- `glab-runner-controller` — Manage runner controllers and orchestration (admin-only, experimental)
+- `glab-ci` — View and manage CI/CD pipelines and jobs
+- `glab-job` — Retry, cancel, trace logs for individual jobs
+
+## Command Reference
+
+```
+glab runner <command> [--flags]
+
+Commands:
+  list    Get a list of runners available to the user
+  pause   Pause a runner
+  delete  Delete a runner
+
+Flags (list):
+  --all          List all runners (instance-level, admin only)
+  --output       Format output as: text, json
+  --page         Page number
+  --per-page     Number of items per page
+  --repo         Select a repository
+  -h, --help     Show help
+
+Flags (pause / delete):
+  --force        Skip confirmation prompt (delete only)
+  --repo         Select a repository
+  -h, --help     Show help
+```

--- a/glab-workitems/SKILL.md
+++ b/glab-workitems/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: glab-workitems
+description: List and manage GitLab work items (tasks, OKRs, key results, epics). Use when working with GitLab's work item types beyond standard issues. Triggers on work items, tasks, OKRs, key results, epic list, workitems list.
+---
+
+# glab workitems
+
+List and manage GitLab work items — the next-generation work tracking format in GitLab that supports tasks, OKRs, key results, epics, and more.
+
+> **Added in glab v1.87.0**
+
+## What Are Work Items?
+
+Work items are GitLab's unified work tracking model. They extend beyond traditional issues to support:
+- **Tasks** — sub-tasks within an issue
+- **OKRs** — Objectives and Key Results
+- **Key Results** — measurable outcomes linked to OKRs
+- **Epics** (next-gen) — large bodies of work across milestones
+- **Incidents** — linked to incident management
+
+## Quick Start
+
+```bash
+# List work items in current project
+glab workitems list
+
+# List in a specific project
+glab workitems list --repo owner/project
+
+# Output as JSON
+glab workitems list --output json
+```
+
+## Common Workflows
+
+### List Work Items
+
+```bash
+# All work items (default: open)
+glab workitems list
+
+# Filter by type
+glab workitems list --type Task
+glab workitems list --type OKR
+glab workitems list --type KeyResult
+glab workitems list --type Epic
+
+# Filter by state
+glab workitems list --state opened
+glab workitems list --state closed
+
+# JSON for scripting
+glab workitems list --output json | python3 -c "
+import sys, json
+items = json.load(sys.stdin)
+for item in items:
+    print(f\"{item['iid']}: {item['title']} [{item['type']}]\")
+"
+```
+
+### Use with a Specific Repo or Group
+
+```bash
+# Specific repo
+glab workitems list --repo mygroup/myproject
+
+# Group-level work items
+glab workitems list --group mygroup
+```
+
+## Work Items vs Issues
+
+| Feature | Issues | Work Items |
+|---|---|---|
+| Standard bug/feature tracking | ✅ | ✅ |
+| Tasks (sub-tasks) | ❌ | ✅ |
+| OKRs / Key Results | ❌ | ✅ |
+| Next-gen Epics | ❌ | ✅ |
+| CLI support | Full | `list` (v1.87.0) |
+
+Use `glab issue` for standard issue workflows. Use `glab workitems` when working with tasks, OKRs, or next-gen epics.
+
+## Troubleshooting
+
+**"workitems: command not found":**
+- Requires glab v1.87.0+. Check with `glab version`.
+
+**Empty results when you expect items:**
+- Work items are a separate type from issues. Items created as issues won't appear here unless they've been converted.
+- Check the GitLab UI under the project's "Plan > Work Items" sidebar.
+
+**Type filter returns nothing:**
+- Not all work item types are enabled on every GitLab instance. GitLab SaaS has broader support than self-managed instances.
+
+## Related Skills
+
+- `glab-issue` — Standard issue management
+- `glab-milestone` — Milestones (often used with OKRs)
+- `glab-iteration` — Sprint/iteration management
+- `glab-incident` — Incident management (a work item type)
+
+## Command Reference
+
+```
+glab workitems list [--flags]
+
+Flags:
+  --group        Select a group/subgroup
+  --output       Format output as: text, json
+  --page         Page number
+  --per-page     Number of items per page
+  --repo         Select a repository
+  --state        Filter by state: opened, closed, all
+  --type         Filter by work item type
+  -h, --help     Show help
+```


### PR DESCRIPTION
Closes #28

## Summary

Updates existing sub-skills and adds two new sub-skills to support glab v1.86.0 and v1.87.0.

## Changes

### Updated Skills

| Skill | Change |
|---|---|
| `glab-mcp` | Document auto-enabled JSON output (v1.86.0); note unannotated commands no longer registered as MCP tools |
| `glab-config` | Document new per-host HTTPS proxy configuration with examples |
| `glab-duo` | Add `glab duo update` binary download management command |
| `glab-mr` | Document all new `glab mr list` flags (author, branch filters, draft, label exclusion, order/sort, date range, search) |
| `glab-runner-controller` | Add runner scope subcommands: `create`, `delete`, `list` with examples |

### New Sub-Skills

| Skill | Description |
|---|---|
| `glab-runner` | Runner management: `list`, `pause`, `delete` — with decision tree, status reference, and troubleshooting |
| `glab-workitems` | Work items list command for tasks, OKRs, key results, next-gen epics — includes comparison table vs standard issues |

### Root `SKILL.md`
- Added `glab-runner` and `glab-workitems` to the skill organization index

## Notes
- All new commands require glab v1.87.0+; noted in each skill
- Do not publish to ClawHub until this PR is approved and merged