### PR TITLE
feat: update documentation for glab v1.88.0

### DIFF
--- a/glab-duo/SKILL.md
+++ b/glab-duo/SKILL.md
@@ -23,6 +23,7 @@ description: Interact with GitLab Duo AI assistant for code suggestions and chat
   COMMANDS  
             
     ask <prompt> [--flags]  Generate Git commands from natural language.
+    help [command]          Show help information for duo commands and subcommands.
          
   FLAGS  
          
@@ -49,6 +50,18 @@ glab duo --version
 ```
 
 **When to use:** Run `glab duo update` after upgrading glab to ensure the Duo AI binary matches your CLI version. If `glab duo ask` stops working after a glab upgrade, this is usually the fix.
+
+## v1.88.0 Changes
+
+### `glab duo help` subcommand
+
+```bash
+# Show help for all duo commands
+glab duo help
+
+# Show help for a specific subcommand
+glab duo help ask
+```
 
 ## Subcommands
 

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-mr
-description: Create, view, manage, approve, and merge GitLab merge requests. Use when working with MRs: creating from branches/issues, reviewing, approving, adding comments, checking out locally, viewing diffs, rebasing, merging, or managing state. Triggers on merge request, MR, pull request, PR, review, approve, merge.
+description: Create, view, manage, approve, and merge GitLab merge requests. Use when working with MRs: creating from branches/issues, reviewing, approving, adding comments, resolving discussion threads, checking out locally, viewing diffs, rebasing, merging, or managing state. Triggers on merge request, MR, pull request, PR, review, approve, merge, resolve thread.
 ---
 
 # glab mr
@@ -60,6 +60,12 @@ glab mr create --draft --title "WIP: Feature X"
 3. **Leave feedback:**
    ```bash
    glab mr note 123 -m "Looks good, one question about the cache logic"
+
+   # Resolve a discussion thread while adding a note (v1.88.0+)
+   glab mr note 123 --resolve <discussion-id> -m "Fixed, addressed in latest commit."
+
+   # Reopen a resolved thread
+   glab mr note 123 --unresolve <discussion-id>
    ```
 
 4. **Approve:**
@@ -259,6 +265,18 @@ whether each comment landed inline or fell back to general.
 
 ---
 
+### Filtering discussion threads by resolution (v1.88.0+)
+
+```bash
+# Show only unresolved discussion threads on an MR
+glab mr view 123 --unresolved
+
+# Show only resolved threads
+glab mr view 123 --resolved
+```
+
+Useful for quickly checking which review threads still need attention before merging.
+
 ## v1.87.0 Changes: New `glab mr list` Flags
 
 The following flags were added to `glab mr list` in v1.87.0:
@@ -307,6 +325,11 @@ glab mr list \
   --search "auth" \
   --created-after 2026-01-01
 ```
+
+## v1.88.0 Changes
+
+- `glab mr note`: Added `--resolve <discussion-id>` and `--unresolve <discussion-id>` flags to resolve/reopen discussion threads while adding a note
+- `glab mr view`: Added `--resolved` and `--unresolved` flags to filter displayed discussion threads by resolution status
 
 ## Command reference
 

--- a/glab-runner/SKILL.md
+++ b/glab-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-runner
-description: Manage GitLab CI/CD runners — list, pause, and delete runners at project, group, or instance level. Use when viewing runner status, temporarily pausing a runner, or removing a decommissioned runner. Triggers on runner, glab runner, list runners, pause runner, delete runner, CI runner.
+description: Manage GitLab CI/CD runners — list, assign, unassign, pause, and delete runners at project, group, or instance level. Use when viewing runner status, assigning runners to projects, temporarily pausing a runner, or removing a decommissioned runner. Triggers on runner, glab runner, list runners, assign runner, unassign runner, pause runner, delete runner, CI runner.
 ---
 
 # glab runner
@@ -128,11 +128,40 @@ Do you need the runner gone permanently?
 - Runner may be shared/group-level (requires higher privileges).
 - Check if runner is assigned to multiple projects; removing from one project may require project-level deletion vs instance-level.
 
+### Assign / Unassign Runners to Projects (v1.88.0+)
+
+Assign an existing runner to a project so it can pick up jobs:
+
+```bash
+# Assign a runner to the current project
+glab runner assign <runner-id>
+
+# Assign to a specific project
+glab runner assign <runner-id> --repo owner/project
+```
+
+Remove a runner from a project (does not delete the runner):
+
+```bash
+# Unassign from current project
+glab runner unassign <runner-id>
+
+# Unassign from a specific project
+glab runner unassign <runner-id> --repo owner/project
+```
+
+**Note:** Assigning/unassigning requires at least Maintainer role on the project. This is different from `glab runner delete` which permanently removes the runner.
+
 ## Related Skills
 
 - `glab-runner-controller` — Manage runner controllers and orchestration (admin-only, experimental)
 - `glab-ci` — View and manage CI/CD pipelines and jobs
 - `glab-job` — Retry, cancel, trace logs for individual jobs
+
+## v1.88.0 Changes
+
+- Added `glab runner assign <runner-id>` — assign a runner to a project
+- Added `glab runner unassign <runner-id>` — unassign a runner from a project
 
 ## Command Reference
 
@@ -140,9 +169,11 @@ Do you need the runner gone permanently?
 glab runner <command> [--flags]
 
 Commands:
-  list    Get a list of runners available to the user
-  pause   Pause a runner
-  delete  Delete a runner
+  list      Get a list of runners available to the user
+  assign    Assign a runner to a project (v1.88.0+)
+  unassign  Unassign a runner from a project (v1.88.0+)
+  pause     Pause a runner
+  delete    Delete a runner
 
 Flags (list):
   --all          List all runners (instance-level, admin only)


### PR DESCRIPTION
## Summary

Updates skill documentation to reflect new features in glab v1.88.0.

Closes #36

## Files Changed

### `glab-mr/SKILL.md`
- Updated description to include thread resolution
- Documented `glab mr note --resolve` and `--unresolve` flags
- Documented `glab mr view --resolved` and `--unresolved` filtering flags
- Added v1.88.0 changelog section

### `glab-runner/SKILL.md`
- Updated description to include assign/unassign
- Documented `glab runner assign <runner-id>` command
- Documented `glab runner unassign <runner-id>` command
- Added v1.88.0 changelog section

### `glab-duo/SKILL.md`
- Documented `glab duo help` subcommand
- Added v1.88.0 changelog section

## glab v1.88.0 Release Notes Reference
- feat(mr note): add --resolve and --unresolve flags
- feat(mr view): add --resolved and --unresolved filtering flags
- feat: add new command for assigning the project to a runner
- feat: add new command for unassigning the runner from the project
- feat(duo cli): add support for help command
