### PR TITLE
fix: retry GitLab inline MR comments with computed line_code

### DIFF
--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -270,8 +270,14 @@ Batch file format:
 ]
 ```
 
-The script auto-reads your token from glab config, fetches fresh SHAs, and reports
-whether each comment landed inline or fell back to general.
+The script auto-reads your token from glab config, fetches fresh SHAs and diffs, and uses a two-step anchoring strategy:
+1. Try the normal `position[new_line]` inline payload first.
+2. If GitLab rejects it with a `line_code` validation error, compute the diff anchor and retry with `position[line_range][start/end][line_code]`.
+
+That retry path is the preferred recovery for failures like:
+- `400 Bad request - Note {:line_code=>["can't be blank", "must be a valid line code"]}`
+
+Only if that retry also fails should your broader review workflow fall back to a root MR note that clearly says inline anchoring failed while preserving the exact finding text and reviewer identity.
 
 ---
 

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -193,7 +193,7 @@ payload = {
         "position_type": "text",
         "new_path": "src/utils/helpers.ts",
         "new_line": 16,
-        "old_path": "src/utils/helpers.ts",  # same as new_path
+        "old_path": "src/utils/helpers.ts",  # for renamed files, use the diff's actual old_path
         "old_line": None                       # None = added line
     }
 }

--- a/scripts/README-inline-comments.md
+++ b/scripts/README-inline-comments.md
@@ -88,12 +88,13 @@ Example `comments.json`:
 ## How It Works
 
 1. **Reads the GitLab token** from `GITLAB_TOKEN` or glab config
-2. **Fetches MR metadata and diffs** to get:
+2. **Fetches MR metadata and all diff pages** to get:
    - Project ID
    - Base SHA (target branch commit)
    - Head SHA (source branch commit)
    - Start SHA (merge base commit)
    - Raw file diff text for anchor recovery
+   - Actual `old_path` / `new_path` values for renamed-file anchors
 3. **Builds JSON payload** with position data:
    ```json
    {
@@ -112,8 +113,9 @@ Example `comments.json`:
 5. **If GitLab rejects the simple payload with a `line_code` validation error**:
    - Parse the file diff
    - Derive the correct old/new diff line pair for the target line
-   - Compute `sha1(file_path) + '_' + oldLine + '_' + newLine`
+   - Compute `sha1(diff_path) + '_' + oldLine + '_' + newLine`
    - Retry using `position[line_range][start/end][line_code]`
+   - Reuse the diff's actual `old_path` / `new_path` when the file was renamed
 6. **Validates response** - Checks that note type is `DiffNote` (inline) not `DiscussionNote` (general)
 
 ## Output

--- a/scripts/README-inline-comments.md
+++ b/scripts/README-inline-comments.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `add-inline-comment.sh` script enables posting inline code review comments to GitLab merge requests at specific file lines. This is more effective than general MR comments because developers can see feedback directly in context without hunting through code.
+The `post-inline-comment.py` helper posts inline code review comments to GitLab merge requests at specific file lines. It is the preferred helper because it can recover from GitLab `line_code` validation failures by computing the diff `line_code` and retrying with `position[line_range][start/end][line_code]`.
 
 ## Why Use Inline Comments?
 
@@ -19,77 +19,81 @@ The `add-inline-comment.sh` script enables posting inline code review comments t
 ## Installation
 
 ```bash
-# The script is already in the gitlab-cli-skills repo
+# The helper is already in the gitlab-cli-skills repo
 cd /path/to/gitlab-cli-skills/scripts
-chmod +x add-inline-comment.sh
+chmod +x post-inline-comment.py
 
 # Optional: Add to PATH for global access
-ln -s $(pwd)/add-inline-comment.sh ~/.local/bin/add-inline-comment
+ln -s "$(pwd)/post-inline-comment.py" ~/.local/bin/post-inline-comment
 ```
 
 ## Requirements
 
 - **glab CLI** - Configured and authenticated (`glab auth login`)
-- **jq** - For JSON parsing (`apt install jq` or `brew install jq`)
-- **curl** - For API calls (usually pre-installed)
+- **Python 3** - Stdlib only, no pip install needed
 
 ## Usage
 
 ```bash
-add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
+post-inline-comment.py --project <group/project> --mr <mr_iid> --file <file_path> --line <line_number> --body <comment_text>
 ```
 
 ### Parameters
 
 | Parameter | Description | Example |
 |-----------|-------------|---------|
-| `repo` | Repository path | `owner/repo` |
-| `mr_iid` | Merge request IID (numeric) | `42` |
-| `file_path` | File path relative to repo root | `src/main.js` |
-| `line_number` | Line number in NEW version | `100` |
-| `comment_text` | Comment (supports markdown) | `Bug: Add null check` |
+| `project` | Repository path | `owner/repo` |
+| `mr` | Merge request IID (numeric) | `42` |
+| `file` | File path relative to repo root | `src/main.js` |
+| `line` | Line number in NEW version | `100` |
+| `body` | Comment (supports markdown) | `Bug: Add null check` |
 
 ### Examples
 
 **Simple comment:**
 ```bash
-add-inline-comment.sh \
-  "owner/repo" \
-  "42" \
-  "src/components/Button.tsx" \
-  "25" \
-  "Consider using a more descriptive variable name here"
+post-inline-comment.py \
+  --project "owner/repo" \
+  --mr 42 \
+  --file "src/components/Button.tsx" \
+  --line 25 \
+  --body "Consider using a more descriptive variable name here"
 ```
 
 **Bug report with markdown:**
 ```bash
-add-inline-comment.sh \
-  "owner/repo" \
-  "42" \
-  "src/utils/validator.js" \
-  "10" \
-  "**Bug**: This regex doesn't handle edge case when input is \`null\`. Add: \`if (!input) return false;\`"
+post-inline-comment.py \
+  --project "owner/repo" \
+  --mr 42 \
+  --file "src/utils/validator.js" \
+  --line 10 \
+  --body "**Bug**: This regex doesn't handle edge case when input is \`null\`. Add: \`if (!input) return false;\`"
 ```
 
 **Multiple comments (batch review):**
 ```bash
-#!/bin/bash
-REPO="owner/repo"
-MR_IID="42"
+python3 post-inline-comment.py --project "owner/repo" --mr 42 --batch comments.json
+```
 
-add-inline-comment.sh "$REPO" "$MR_IID" "src/api.js" 15 "Add error handling"
-add-inline-comment.sh "$REPO" "$MR_IID" "src/api.js" 22 "Use async/await instead of .then()"
-add-inline-comment.sh "$REPO" "$MR_IID" "src/types.ts" 8 "Missing JSDoc comment"
+Example `comments.json`:
+
+```json
+[
+  { "file": "src/api.js", "line": 15, "body": "Add error handling" },
+  { "file": "src/api.js", "line": 22, "body": "Use async/await instead of .then()" },
+  { "file": "src/types.ts", "line": 8, "body": "Missing JSDoc comment" }
+]
 ```
 
 ## How It Works
 
-1. **Extracts GitLab token** from `~/.config/glab-cli/config.yml`
-2. **Fetches MR metadata** via `glab api` to get:
+1. **Reads the GitLab token** from `GITLAB_TOKEN` or glab config
+2. **Fetches MR metadata and diffs** to get:
    - Project ID
    - Base SHA (target branch commit)
    - Head SHA (source branch commit)
    - Start SHA (merge base commit)
+   - Raw file diff text for anchor recovery
 3. **Builds JSON payload** with position data:
    ```json
    {
@@ -104,8 +108,13 @@ add-inline-comment.sh "$REPO" "$MR_IID" "src/types.ts" 8 "Missing JSDoc comment"
      }
    }
    ```
-4. **Posts to GitLab API** via `curl` (using `glab api` doesn't work for nested JSON)
-5. **Validates response** - Checks that note type is `DiffNote` (inline) not `DiscussionNote` (general)
+4. **Posts to GitLab API** with a JSON body
+5. **If GitLab rejects the simple payload with a `line_code` validation error**:
+   - Parse the file diff
+   - Derive the correct old/new diff line pair for the target line
+   - Compute `sha1(file_path) + '_' + oldLine + '_' + newLine`
+   - Retry using `position[line_range][start/end][line_code]`
+6. **Validates response** - Checks that note type is `DiffNote` (inline) not `DiscussionNote` (general)
 
 ## Output
 
@@ -150,20 +159,21 @@ glab auth login
 glab auth status  # Verify authentication
 ```
 
-### "Position is invalid"
+### `line_code` validation error
 
-**Cause:** Line number doesn't exist in the file diff.
+**Cause:** For some MR/file/diff combinations, GitLab rejects the simpler `new_line`/`old_line` payload unless the request also includes computed `position[line_range][start/end][line_code]` values.
 
 **Fix:**
-- Verify the line number exists in the **NEW** version of the file
-- Check that the file was actually changed in this MR
-- Use `glab mr diff <iid>` to see what lines are in the diff
+- Use `post-inline-comment.py`, which retries automatically with computed `line_code`
+- Verify the target line exists in the MR diff
+- Verify the file path matches the diff path exactly
 
 ### Comment appears as general, not inline
 
-**Cause:** This shouldn't happen if the script succeeded, but if it does:
+**Cause:** Inline anchoring still failed after the retry path.
 - File path might be incorrect (must be relative to repo root)
 - Line number might be outside the diff range
+- The target line may not map cleanly to the MR diff
 
 **Debug:**
 ```bash
@@ -191,8 +201,8 @@ if echo "$DIFF" | grep -q "console.log"; then
     LINE=$(echo "$DIFF" | grep -n "console.log" | head -1 | cut -d: -f1)
     FILE=$(echo "$DIFF" | grep -B20 "console.log" | grep "^+++" | head -1 | cut -d/ -f2-)
     
-    add-inline-comment.sh "$REPO" "$MR_IID" "$FILE" "$LINE" \
-        "⚠️ Remove console.log before merging"
+    python3 post-inline-comment.py --project "$REPO" --mr "$MR_IID" --file "$FILE" --line "$LINE" \
+        --body "⚠️ Remove console.log before merging"
 fi
 
 # Check for TODO comments
@@ -216,7 +226,7 @@ while IFS=: read -r file line message; do
     # Remove absolute path prefix
     rel_path="${file#/absolute/path/to/repo/}"
     
-    add-inline-comment.sh "$REPO" "$MR_IID" "$rel_path" "$line" "ESLint: $message"
+    python3 post-inline-comment.py --project "$REPO" --mr "$MR_IID" --file "$rel_path" --line "$line" --body "ESLint: $message"
 done
 ```
 
@@ -254,12 +264,12 @@ Test on a personal repo before using on production MRs:
 glab mr create --title "Test MR" --repo owner/test-repo
 
 # Post test comment
-./add-inline-comment.sh \
-  "owner/test-repo" \
-  "1" \
-  "README.md" \
-  "1" \
-  "TEST: This is a test inline comment"
+./post-inline-comment.py \
+  --project "owner/test-repo" \
+  --mr 1 \
+  --file "README.md" \
+  --line 1 \
+  --body "TEST: This is a test inline comment"
 
 # Verify in GitLab UI
 # Delete test comment and MR when done

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,23 +56,23 @@ Debug CI failures by showing failed job logs.
 2. Shows last 50 lines of each failed job's log
 3. Provides next steps for debugging
 
-### `add-inline-comment.sh`
+### `post-inline-comment.py`
 
-Post inline code review comments at specific line numbers in MR diffs.
+Post inline code review comments at specific line numbers in MR diffs, with automatic recovery when GitLab requires computed `line_code` anchors.
 
 ```bash
-./scripts/add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
+./scripts/post-inline-comment.py --project <group/project> --mr <mr_iid> --file <file_path> --line <line_number> --body <comment_text>
 
 # Examples
-./scripts/add-inline-comment.sh owner/repo 42 "src/main.js" 100 "Bug: Add null check"
-./scripts/add-inline-comment.sh owner/repo 42 "lib/util.py" 25 "**Performance**: Use dict comprehension"
+./scripts/post-inline-comment.py --project owner/repo --mr 42 --file "src/main.js" --line 100 --body "Bug: Add null check"
+./scripts/post-inline-comment.py --project owner/repo --mr 42 --file "lib/util.py" --line 25 --body "**Performance**: Use dict comprehension"
 ```
 
 **What it does:**
-1. Fetches MR metadata (project ID, commit SHAs)
-2. Posts inline comment at exact file:line location
-3. Comment appears in GitLab UI directly in the diff
-4. Returns URL to the comment
+1. Fetches MR metadata (current SHAs) and diffs
+2. Tries the normal inline discussion payload first
+3. If GitLab returns a `line_code` validation error, computes the diff `line_code` and retries with `position[line_range][start/end][line_code]`
+4. Reports whether the comment landed inline and whether the retry path was needed
 
 **Documentation:** See `scripts/README-inline-comments.md` for detailed usage and integration examples.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,10 +69,11 @@ Post inline code review comments at specific line numbers in MR diffs, with auto
 ```
 
 **What it does:**
-1. Fetches MR metadata (current SHAs) and diffs
+1. Fetches MR metadata (current SHAs) and all MR diff pages
 2. Tries the normal inline discussion payload first
 3. If GitLab returns a `line_code` validation error, computes the diff `line_code` and retries with `position[line_range][start/end][line_code]`
-4. Reports whether the comment landed inline and whether the retry path was needed
+4. Preserves the diff's actual `old_path`/`new_path` metadata so renamed files anchor correctly
+5. Reports whether the comment landed inline and whether the retry path was needed
 
 **Documentation:** See `scripts/README-inline-comments.md` for detailed usage and integration examples.
 

--- a/scripts/post-inline-comment.py
+++ b/scripts/post-inline-comment.py
@@ -229,6 +229,13 @@ def _api_get(token, url):
         return json.loads(resp.read())
 
 
+def _api_get_with_headers(token, url):
+    """Authenticated GET request, returns (parsed_json, headers)."""
+    req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": token})
+    with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
+        return json.loads(resp.read()), resp.headers
+
+
 def get_mr_versions(token, host, project_id, mr_iid):
     """Fetch current HEAD/START/BASE SHAs for an MR."""
     url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/versions"
@@ -244,9 +251,24 @@ def get_mr_versions(token, host, project_id, mr_iid):
 
 
 def get_mr_diffs(token, host, project_id, mr_iid):
-    """Fetch MR diffs so we can compute line_code anchors when GitLab requires them."""
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/diffs?per_page=100"
-    return _api_get(token, url)
+    """Fetch all MR diffs so we can compute line_code anchors when GitLab requires them."""
+    diffs = []
+    page = 1
+
+    while True:
+        url = (
+            f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/diffs"
+            f"?per_page=100&page={page}"
+        )
+        page_diffs, headers = _api_get_with_headers(token, url)
+        diffs.extend(page_diffs)
+
+        next_page = (headers.get("X-Next-Page") or "").strip()
+        if not next_page:
+            break
+        page = int(next_page)
+
+    return diffs
 
 
 def find_file_diff(diffs, file_path):
@@ -310,7 +332,16 @@ def compute_line_code(file_path, old_line, new_line):
     return f"{file_hash}_{old_line}_{new_line}"
 
 
-def build_inline_payload(shas, file_path, line_number, body):
+def get_position_paths(diff_entry, requested_file_path):
+    """Return the old/new paths GitLab expects for this diff position."""
+    return {
+        "old_path": diff_entry.get("old_path") or requested_file_path,
+        "new_path": diff_entry.get("new_path") or requested_file_path,
+    }
+
+
+def build_inline_payload(shas, diff_entry, file_path, line_number, body):
+    paths = get_position_paths(diff_entry, file_path)
     return {
         "body": body,
         "position": {
@@ -318,22 +349,24 @@ def build_inline_payload(shas, file_path, line_number, body):
             "start_sha":     shas["start_sha"],
             "head_sha":      shas["head_sha"],
             "position_type": "text",
-            "new_path":      file_path,
+            "new_path":      paths["new_path"],
             "new_line":      line_number,
-            "old_path":      file_path,
+            "old_path":      paths["old_path"],
             "old_line":      None,
         }
     }
 
 
-def build_line_range_payload(shas, file_path, body, anchor):
+def build_line_range_payload(shas, diff_entry, file_path, body, anchor):
+    paths = get_position_paths(diff_entry, file_path)
+    line_code_path = paths["new_path"] if anchor["type"] == "new" else paths["old_path"]
     point = {
         "type": anchor["type"],
-        "line_code": compute_line_code(file_path, anchor["old_line"], anchor["new_line"]),
+        "line_code": compute_line_code(line_code_path, anchor["old_line"], anchor["new_line"]),
     }
-    if anchor["old_line"]:
+    if anchor["old_line"] is not None:
         point["old_line"] = anchor["old_line"]
-    if anchor["new_line"]:
+    if anchor["new_line"] is not None:
         point["new_line"] = anchor["new_line"]
 
     return {
@@ -343,8 +376,8 @@ def build_line_range_payload(shas, file_path, body, anchor):
             "start_sha":     shas["start_sha"],
             "head_sha":      shas["head_sha"],
             "position_type": "text",
-            "old_path":      file_path,
-            "new_path":      file_path,
+            "old_path":      paths["old_path"],
+            "new_path":      paths["new_path"],
             "line_range": {
                 "start": dict(point),
                 "end":   dict(point),
@@ -386,17 +419,18 @@ def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path,
     """
     url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions"
 
+    diff_entry = find_file_diff(diffs, file_path)
+
     try:
-        r = post_discussion(token, url, build_inline_payload(shas, file_path, line_number, body))
+        r = post_discussion(token, url, build_inline_payload(shas, diff_entry, file_path, line_number, body))
         used_line_code_retry = False
     except Exception as e:
         error_text = str(e)
         if not is_line_code_validation_error(error_text):
             raise
 
-        diff_entry = find_file_diff(diffs, file_path)
         anchor = compute_diff_anchor(diff_entry.get("diff", ""), line_number)
-        retry_payload = build_line_range_payload(shas, file_path, body, anchor)
+        retry_payload = build_line_range_payload(shas, diff_entry, file_path, body, anchor)
         r = post_discussion(token, url, retry_payload)
         used_line_code_retry = True
 

--- a/scripts/post-inline-comment.py
+++ b/scripts/post-inline-comment.py
@@ -55,6 +55,7 @@ REQUIREMENTS:
 """
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -242,15 +243,75 @@ def get_mr_versions(token, host, project_id, mr_iid):
     }
 
 
-def post_inline_comment(token, host, project_id, mr_iid, shas, file_path, line_number, body):
-    """
-    Post a single inline comment on a MR diff using a JSON body.
-    Returns (disc_id, is_inline) tuple.
-    is_inline=False means GitLab rejected the position and fell back to a general comment.
-    """
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions"
+def get_mr_diffs(token, host, project_id, mr_iid):
+    """Fetch MR diffs so we can compute line_code anchors when GitLab requires them."""
+    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/diffs?per_page=100"
+    return _api_get(token, url)
 
-    payload = {
+
+def find_file_diff(diffs, file_path):
+    """Return the diff entry matching file_path on either old or new side."""
+    for diff in diffs:
+        if diff.get("new_path") == file_path or diff.get("old_path") == file_path:
+            return diff
+    raise ValueError(f"Could not find diff for file '{file_path}' in this MR.")
+
+
+def compute_diff_anchor(diff_text, target_new_line):
+    """Map a target new-side line number to the diff's old/new anchor pair."""
+    old_line = None
+    new_line = None
+
+    for raw_line in diff_text.splitlines():
+        hunk = re.match(r'^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@', raw_line)
+        if hunk:
+            old_line = int(hunk.group(1))
+            new_line = int(hunk.group(2))
+            continue
+
+        if old_line is None or new_line is None:
+            continue
+
+        if raw_line.startswith('\\'):
+            continue
+
+        if raw_line.startswith('+'):
+            if new_line == target_new_line:
+                return {
+                    "type": "new",
+                    "old_line": 0,
+                    "new_line": new_line,
+                }
+            new_line += 1
+            continue
+
+        if raw_line.startswith('-'):
+            old_line += 1
+            continue
+
+        if new_line == target_new_line:
+            return {
+                "type": "new",
+                "old_line": old_line,
+                "new_line": new_line,
+            }
+        old_line += 1
+        new_line += 1
+
+    raise ValueError(
+        f"Could not map new-side line {target_new_line} to a diff anchor. "
+        "Make sure the line exists in the MR diff."
+    )
+
+
+def compute_line_code(file_path, old_line, new_line):
+    """GitLab diff line code format: sha1(path)_{old}_{new}."""
+    file_hash = hashlib.sha1(file_path.encode("utf-8")).hexdigest()
+    return f"{file_hash}_{old_line}_{new_line}"
+
+
+def build_inline_payload(shas, file_path, line_number, body):
+    return {
         "body": body,
         "position": {
             "base_sha":      shas["base_sha"],
@@ -259,11 +320,40 @@ def post_inline_comment(token, host, project_id, mr_iid, shas, file_path, line_n
             "position_type": "text",
             "new_path":      file_path,
             "new_line":      line_number,
-            "old_path":      file_path,  # same as new_path for added/new files
-            "old_line":      None,       # None = added line (no old-side anchor)
+            "old_path":      file_path,
+            "old_line":      None,
         }
     }
 
+
+def build_line_range_payload(shas, file_path, body, anchor):
+    point = {
+        "type": anchor["type"],
+        "line_code": compute_line_code(file_path, anchor["old_line"], anchor["new_line"]),
+    }
+    if anchor["old_line"]:
+        point["old_line"] = anchor["old_line"]
+    if anchor["new_line"]:
+        point["new_line"] = anchor["new_line"]
+
+    return {
+        "body": body,
+        "position": {
+            "base_sha":      shas["base_sha"],
+            "start_sha":     shas["start_sha"],
+            "head_sha":      shas["head_sha"],
+            "position_type": "text",
+            "old_path":      file_path,
+            "new_path":      file_path,
+            "line_range": {
+                "start": dict(point),
+                "end":   dict(point),
+            },
+        }
+    }
+
+
+def post_discussion(token, url, payload):
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         url,
@@ -277,16 +367,44 @@ def post_inline_comment(token, host, project_id, mr_iid, shas, file_path, line_n
 
     try:
         with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-            r = json.loads(resp.read())
+            return json.loads(resp.read())
     except urllib.error.HTTPError as e:
         error_body = e.read().decode(errors="replace")
         raise RuntimeError(f"HTTP {e.code}: {error_body[:500]}")
 
-    note     = r.get("notes", [{}])[0]
-    disc_id  = r.get("id")
+
+def is_line_code_validation_error(error_text):
+    return "line_code" in error_text and "valid" in error_text.lower()
+
+
+def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path, line_number, body):
+    """
+    Post a single inline comment on a MR diff using a JSON body.
+    First try the simple new_line payload; if GitLab rejects it with a line_code
+    validation error, compute the diff anchor and retry with position.line_range.
+    Returns (disc_id, is_inline, used_line_code_retry) tuple.
+    """
+    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions"
+
+    try:
+        r = post_discussion(token, url, build_inline_payload(shas, file_path, line_number, body))
+        used_line_code_retry = False
+    except Exception as e:
+        error_text = str(e)
+        if not is_line_code_validation_error(error_text):
+            raise
+
+        diff_entry = find_file_diff(diffs, file_path)
+        anchor = compute_diff_anchor(diff_entry.get("diff", ""), line_number)
+        retry_payload = build_line_range_payload(shas, file_path, body, anchor)
+        r = post_discussion(token, url, retry_payload)
+        used_line_code_retry = True
+
+    note = r.get("notes", [{}])[0]
+    disc_id = r.get("id")
     is_inline = note.get("position") is not None
 
-    return disc_id, is_inline
+    return disc_id, is_inline, used_line_code_retry
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -331,8 +449,9 @@ def main():
     print(f"Fetching current HEAD SHAs for MR !{args.mr}...")
     try:
         shas = get_mr_versions(token, host, project_id, args.mr)
+        diffs = get_mr_diffs(token, host, project_id, args.mr)
     except Exception as e:
-        print(f"ERROR: Could not fetch MR versions: {e}", file=sys.stderr)
+        print(f"ERROR: Could not fetch MR metadata/diffs: {e}", file=sys.stderr)
         sys.exit(1)
     print(f"  head_sha: {shas['head_sha'][:12]}...")
 
@@ -346,16 +465,22 @@ def main():
         print(f"  Body: {body[:80]}{'...' if len(body) > 80 else ''}")
 
         try:
-            disc_id, is_inline = post_inline_comment(
-                token, host, project_id, args.mr, shas, file_path, line_number, body
+            disc_id, is_inline, used_line_code_retry = post_inline_comment(
+                token, host, project_id, args.mr, shas, diffs, file_path, line_number, body
             )
-            status = "✅ INLINE" if is_inline else "⚠️  GENERAL (position rejected — check line number)"
+            if is_inline and used_line_code_retry:
+                status = "✅ INLINE (line_code retry)"
+            elif is_inline:
+                status = "✅ INLINE"
+            else:
+                status = "⚠️  GENERAL (position rejected — check line number)"
             print(f"  {status} | disc_id: {disc_id}")
             results.append({
-                "disc_id":   disc_id,
-                "is_inline": is_inline,
-                "file":      file_path,
-                "line":      line_number,
+                "disc_id":              disc_id,
+                "is_inline":            is_inline,
+                "used_line_code_retry": used_line_code_retry,
+                "file":                 file_path,
+                "line":                 line_number,
             })
         except Exception as e:
             print(f"  ❌ FAILED: {e}", file=sys.stderr)
@@ -364,9 +489,10 @@ def main():
     # Summary
     print(f"\n{'=' * 50}")
     inline_count  = sum(1 for r in results if r.get("is_inline") is True)
+    retried_count = sum(1 for r in results if r.get("used_line_code_retry") is True)
     general_count = sum(1 for r in results if r.get("is_inline") is False)
     error_count   = sum(1 for r in results if "error" in r)
-    print(f"Summary: {inline_count} inline ✅  {general_count} general ⚠️  {error_count} failed ❌")
+    print(f"Summary: {inline_count} inline ✅  {retried_count} retried-with-line_code 🔁  {general_count} general ⚠️  {error_count} failed ❌")
 
     if general_count:
         print(


### PR DESCRIPTION
## Summary
- update `scripts/post-inline-comment.py` to retry inline diff discussions with computed `position[line_range][start/end][line_code]` when GitLab rejects the simple line-based payload
- document the `line_code` validation failure mode and the expected retry/fallback workflow in the MR guidance
- point script docs at the Python helper that now handles the retry path

Closes #56

## Verification
- `python3 -m py_compile scripts/post-inline-comment.py`
- `gh auth status`
- `gh api user`
