### PR TITLE
fix: honor build-claude-skill output path

### DIFF
--- a/scripts/build-claude-skill.sh
+++ b/scripts/build-claude-skill.sh
@@ -22,8 +22,9 @@ set -euo pipefail
 
 # ── Resolve paths ─────────────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-OUTPUT_ZIP="$REPO_ROOT/claude-skill.zip"
+DEFAULT_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$DEFAULT_REPO_ROOT"
+OUTPUT_ZIP=""
 
 # ── Parse args ────────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -33,6 +34,16 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+if [[ -z "$OUTPUT_ZIP" ]]; then
+  OUTPUT_ZIP="$REPO_ROOT/claude-skill.zip"
+else
+  case "$OUTPUT_ZIP" in
+    /*) ;;
+    *) OUTPUT_ZIP="$PWD/$OUTPUT_ZIP" ;;
+  esac
+fi
 
 # ── Temp workspace ────────────────────────────────────────────────────────────
 WORK_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- fix `scripts/build-claude-skill.sh` so output path resolution happens after argument parsing
- default the ZIP output path from the resolved repo root only when `--output` is not provided
- verify the ZIP is written to the requested path during a local script test

## Test plan
- run `bash scripts/build-claude-skill.sh --output "$TEST_OUT"`
- verify the ZIP is created at the requested output path
