### PR TITLE
docs: audit glab v1.94.0 release changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A collection of skills for AI coding agents following the Agent Skills format. T
 - [`glab-milestone`](./glab-milestone)
 - [`glab-mr`](./glab-mr)
 - [`glab-opentofu`](./glab-opentofu)
+- [`glab-orbit`](./glab-orbit)
 - [`glab-release`](./glab-release)
 - [`glab-repo`](./glab-repo)
 - [`glab-schedule`](./glab-schedule)
@@ -50,6 +51,7 @@ A collection of skills for AI coding agents following the Agent Skills format. T
 - [`glab-user`](./glab-user)
 - [`glab-variable`](./glab-variable)
 - [`glab-version`](./glab-version)
+- [`glab-workitems`](./glab-workitems)
 
 ## Installation
 
@@ -63,7 +65,7 @@ npx skills add vince-winkintel/gitlab-cli-skills
 
 Claude.ai requires a zip containing exactly one `SKILL.md`. Download the pre-built `claude-skill.zip` from the [latest release](https://github.com/vince-winkintel/gitlab-cli-skills/releases/latest) and upload it in your organization's **Settings → Custom Skills**.
 
-The zip contains a single merged `SKILL.md` combining all 37+ sub-skills into one comprehensive glab reference.
+The zip contains a single merged `SKILL.md` combining all 40+ sub-skills into one comprehensive glab reference.
 
 **Build it yourself:**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -135,6 +135,7 @@ This skill routes to specialized sub-skills by GitLab domain:
 - `glab-api` - Direct REST API calls
 - `glab-cluster` - Kubernetes cluster integration
 - `glab-deploy-key` - Deploy keys for automation
+- `glab-orbit` - GitLab Knowledge Graph / Orbit discovery, schema inspection, and remote query workflows (EXPERIMENTAL)
 - `glab-quick-actions` - GitLab slash command quick actions for batching state changes
 - `glab-stack` - Stacked/dependent merge requests
 - `glab-opentofu` - Terraform/OpenTofu state management

--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,13 @@
-1.13.4
+1.13.5
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- glab v1.94.0
+  - `glab-workitems`: command spelling updated to `glab work-items`; added `create` and `delete` coverage.
+  - `glab-orbit`: new skill coverage for experimental Knowledge Graph / Orbit remote commands.
+  - `glab-mr`: documented `glab mr note create` as the forward note flow, including `--reply`, `--file`, `--line`, and `--old-line`.
+  - `glab-stack`: `glab stack sync` gained `--reviewer`.
 - glab v1.93.0
   - `glab-mr`: `glab mr create` gained `--template`.
   - `glab-issue`: `glab issue create` gained `--template`.

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -65,20 +65,22 @@ glab mr create --draft --title "WIP: Feature X"
 
 3. **Leave feedback:**
    ```bash
-   glab mr note 123 -m "Looks good, one question about the cache logic"
+   # Forward command surface for new MR comments/discussions (v1.94.0+)
+   glab mr note create 123 -m "Looks good, one question about the cache logic"
+
+   # Reply inside an existing discussion thread
+   glab mr note create 123 --reply abc12345 -m "Good catch — updated"
+
+   # Native diff comments on the latest MR version
+   glab mr note create 123 --file src/cache.ts --line 42 -m "Please extract this branch"
+   glab mr note create 123 --file src/cache.ts --old-line 17 -m "Why was this removed?"
 
    # List discussion threads on the MR (experimental)
    glab mr note list 123
 
-   # Resolve a discussion by note/discussion ID (experimental)
+   # Resolve or reopen a discussion by note/discussion ID (experimental)
    glab mr note resolve 3107030349 123
-
-   # Reopen a resolved discussion (experimental)
    glab mr note reopen 3107030349 123
-
-   # Use the explicit subcommands for discussion state changes
-   glab mr note resolve <discussion-id> 123
-   glab mr note reopen <discussion-id> 123
    ```
 
 4. **Approve:**
@@ -150,6 +152,48 @@ glab mr merge 123
 
 **Automation:**
 - Script: `scripts/mr-review-workflow.sh` for automated review + test workflow
+
+## Native MR note flow (`glab mr note create`)
+
+As of glab v1.94.0, `glab mr note create` is the preferred command surface for posting new MR discussions.
+
+### Use native `glab mr note create` when
+
+```bash
+# New top-level discussion/comment
+glab mr note create 123 -m "Please add a regression test"
+
+# Reply to an existing discussion thread
+glab mr note create 123 --reply abc12345 -m "Fixed in the latest push"
+
+# File-level diff comment
+glab mr note create 123 --file src/app.ts -m "General concern on this file"
+
+# Line comment on the new side of the diff
+glab mr note create 123 --file src/app.ts --line 84 -m "This branch can return null"
+
+# Range comment on the new side
+glab mr note create 123 --file src/app.ts --line 84:96 -m "Consider extracting this block"
+
+# Comment on a removed line from the old side
+glab mr note create 123 --file src/app.ts --old-line 37 -m "Why was this guard removed?"
+```
+
+Flag rules worth remembering from the upstream help/docs:
+- `--reply` targets an existing discussion thread instead of starting a new one.
+- `--reply` accepts a full discussion ID or a unique prefix of at least 8 characters.
+- `--line` and `--old-line` require `--file` and cannot be used together.
+- `--file`, `--reply`, and `--unique` are mutually exclusive.
+- Omit both `--line` and `--old-line` when you want a file-level diff comment.
+
+### Keep the helper/script path when
+
+Use the bundled inline-comment helper or raw `glab api` JSON-body approach when you need stronger anchoring guarantees for automation, especially when:
+- you must verify that GitLab created an actual inline discussion rather than silently falling back to a general MR note
+- you are posting many comments in batch
+- you are targeting tricky diffs (new files, renamed files, complex paths, or line-code fallback cases)
+
+`glab mr note create` is now enough for most interactive reply and diff-comment workflows. The helper remains valuable for robust automated review pipelines.
 
 ## Posting Inline Comments on MR Diffs
 
@@ -369,7 +413,7 @@ For complete command documentation and all flags, see [references/commands.md](r
 - `for` - Create MR for an issue
 - `list` - List merge requests
 - `merge` - Merge/accept MR
-- `note` - Add comment to MR; includes `list`, `resolve`, and `reopen` subcommands
+- `note` - MR discussion commands; use `glab mr note create` for new comments, plus `list`, `resolve`, and `reopen`
 - `rebase` - Rebase source branch
 - `reopen` - Reopen merge request
 - `revoke` - Revoke approval

--- a/glab-orbit/SKILL.md
+++ b/glab-orbit/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: glab-orbit
+description: Query the GitLab Knowledge Graph (Orbit) from the CLI. Use when discovering Orbit availability, inspecting schema/tools, running graph queries, or checking graph indexing status. Triggers on orbit, knowledge graph, graph query, orbit schema, orbit remote query, orbit tools.
+---
+
+# glab orbit
+
+Access the GitLab Knowledge Graph (product name: **Orbit**) from `glab`.
+
+In v1.94.0, the user-facing surface is the new experimental `glab orbit` command family, focused on **remote** Knowledge Graph access.
+
+## ⚠️ Experimental Feature
+
+Upstream marks Orbit as **EXPERIMENTAL**:
+- command shape may change
+- the API is gated behind the `knowledge_graph` feature flag
+- access is user-scoped, not project-scoped
+- `glab orbit local` is mentioned as coming soon, but v1.94.0 is effectively about `glab orbit remote`
+
+See: https://docs.gitlab.com/policy/development_stages_support/
+
+## Quick start
+
+```bash
+# First: confirm the service is available for your user
+glab orbit remote status
+
+# Discover the graph model
+glab orbit remote schema
+glab orbit remote tools
+
+# Inspect specific node types
+glab orbit remote schema User Project MergeRequest
+```
+
+## Recommended workflow: discover first, query second
+
+The upstream docs strongly point to a discovery-first flow:
+
+1. `glab orbit remote status` — verify Orbit is enabled and reachable
+2. `glab orbit remote schema` — inspect the ontology (entities, edges, properties)
+3. `glab orbit remote tools` — inspect the authoritative JSON Schema for the query DSL
+4. `glab orbit remote query ...` — run actual graph queries once you know the schema
+
+That order matters because `schema` and `tools` are the source of truth for what the graph exposes and what request bodies are valid.
+
+## Common workflows
+
+### 1) Check service health
+
+```bash
+# Check the default GitLab host for the current repo/user
+glab orbit remote status
+
+# Target a specific GitLab host explicitly
+glab orbit remote status --hostname gitlab.com
+```
+
+Use this first when you're not sure whether Orbit is even enabled for your account or GitLab instance.
+
+### 2) Inspect the ontology
+
+```bash
+# High-level schema overview
+glab orbit remote schema
+
+# Expand selected nodes with full detail
+glab orbit remote schema User Project MergeRequest
+```
+
+Use `schema` to learn what entities exist and which relationships can be traversed.
+
+### 3) Inspect the query DSL schema
+
+```bash
+# Show the MCP tool manifest / DSL schema
+glab orbit remote tools
+```
+
+`tools` returns the authoritative JSON Schema for the query DSL in the `query_graph` tool manifest. Use this when generating or validating query bodies programmatically.
+
+### 4) Run a remote query
+
+`glab orbit remote query` reads a full Orbit query envelope from a file or stdin:
+
+```json
+{
+  "query": { "query_type": "..." },
+  "response_format": "llm"
+}
+```
+
+```bash
+# Query from a file
+glab orbit remote query ./query.json
+
+# Query from stdin
+cat ./query.json | glab orbit remote query -
+
+# Force structured JSON for jq pipelines
+glab orbit remote query --format raw ./query.json
+```
+
+Notes:
+- Default output is `llm`, which is compact and agent-friendly.
+- Use `--format raw` when you want structured JSON for further processing.
+- The query body shape is defined by `glab orbit remote tools`, not by guesswork.
+
+### 5) Check indexing progress
+
+```bash
+# By full path
+glab orbit remote graph-status --full-path gitlab-org/gitlab
+
+# By numeric IDs
+glab orbit remote graph-status --project-id 278964
+glab orbit remote graph-status --namespace-id 9970
+
+# Compact output for agents
+glab orbit remote graph-status --full-path gitlab-org/gitlab --format llm
+```
+
+Use `graph-status` when a query looks incomplete and you need to confirm whether the relevant project/group has been indexed yet.
+
+## Troubleshooting
+
+**Orbit returns 404 / unavailable:**
+- Orbit endpoints are typically behind the `knowledge_graph` feature flag.
+- Upstream documents exit code `2` for endpoint unavailable.
+- Start with `glab orbit remote status` to verify availability before building queries.
+
+**Unauthorized / forbidden:**
+- Orbit access is user-scoped.
+- Re-check `glab auth status` and confirm the current account has access to a Knowledge Graph-enabled namespace.
+- Upstream documents exit code `3` for unauthenticated and `4` for forbidden.
+
+**Rate limited:**
+- Upstream documents exit code `5` for HTTP 429 responses.
+- Slow down query bursts and prefer fewer, broader discovery calls.
+
+**Query body keeps failing validation:**
+- Fetch the current DSL schema with `glab orbit remote tools`.
+- Fetch the ontology with `glab orbit remote schema`.
+- Prefer `--format raw` when debugging exact response structure.
+
+**Need local/offline graph commands:**
+- The v1.94.0 docs only document `glab orbit remote`.
+- `glab orbit local` is mentioned as coming soon, not as current guidance.
+
+## Related skills
+
+- `glab-api` — fall back to direct REST API calls when you need lower-level GitLab access
+- `glab-auth` — verify login state before Orbit calls
+- `glab-mcp` — separate MCP server tooling for AI integrations
+
+## Command reference
+
+```text
+glab orbit remote status [flags]
+  --hostname    Target GitLab host
+
+glab orbit remote schema [node...] [flags]
+  --hostname    Target GitLab host
+
+glab orbit remote tools [flags]
+  --hostname    Target GitLab host
+
+glab orbit remote query [file|-] [flags]
+  --format      llm|raw (default: llm)
+  --hostname    Target GitLab host
+
+glab orbit remote graph-status [flags]
+  --format        raw|llm (default: raw)
+  --full-path     Project/group full path
+  --hostname      Target GitLab host
+  --namespace-id  Group ID
+  --project-id    Project ID
+```

--- a/glab-stack/SKILL.md
+++ b/glab-stack/SKILL.md
@@ -47,19 +47,23 @@ glab stack --help
 
 ## Current behavior
 
-`glab stack sync` supports `--update-base`, `--assignee`, and `--label`.
+`glab stack sync` supports `--update-base`, `--assignee`, `--label`, and (as of glab v1.94.0) `--reviewer`.
 
 ```bash
-# Sync stack and rebase onto updated base branch
+# Sync stack and rebase onto the latest base branch
 glab stack sync --update-base
 
 # Sync stack and set MR metadata during submission
-glab stack sync --assignee @reviewer --label backend
+glab stack sync --assignee @owner --reviewer @reviewer --label backend
+
+# Multiple reviewers can be repeated or comma-separated
+glab stack sync --reviewer user1 --reviewer user2
+glab stack sync --reviewer user1,user2
 ```
 
-Use `--update-base` when the base branch (e.g. `main`) has been updated and you want to rebase your entire stack on top of it before pushing.
+Use `--update-base` when the base branch (for example `main`) has moved and you want to rebase the entire stack before pushing.
 
-Use `--assignee` / `--label` when you want the synced stack's merge requests to pick up reviewer ownership or routing labels as part of the same submission step.
+Use `--assignee`, `--reviewer`, and `--label` when you want `glab stack sync` to submit the stack's merge requests with ownership and routing metadata in the same step.
 
 ## Subcommands
 

--- a/glab-workitems/SKILL.md
+++ b/glab-workitems/SKILL.md
@@ -1,114 +1,178 @@
 ---
 name: glab-workitems
-description: List and manage GitLab work items (tasks, OKRs, key results, epics). Use when working with GitLab's work item types beyond standard issues. Triggers on work items, tasks, OKRs, key results, epic list, workitems list.
+description: Create, list, and delete GitLab work items (tasks, OKRs, key results, epics, incidents, test cases). Use when working with GitLab's work item types beyond standard issues. Triggers on work items, work-items, tasks, OKRs, key results, epics, work item create, work item delete.
 ---
 
-# glab workitems
+# glab work-items
 
-List and manage GitLab work items — the next-generation work tracking format in GitLab that supports tasks, OKRs, key results, epics, and more.
+Create, list, and delete GitLab work items — GitLab's unified work tracking model for tasks, OKRs, key results, epics, incidents, test cases, and related planning objects.
 
-## What Are Work Items?
+## ⚠️ Experimental Feature
 
-Work items are GitLab's unified work tracking model. They extend beyond traditional issues to support:
-- **Tasks** — sub-tasks within an issue
-- **OKRs** — Objectives and Key Results
-- **Key Results** — measurable outcomes linked to OKRs
-- **Epics** (next-gen) — large bodies of work across milestones
-- **Incidents** — linked to incident management
+`glab work-items` is still marked **EXPERIMENTAL** upstream:
+- command shape may still change
+- availability can differ by GitLab version / feature flags
+- some work item types are only meaningful at group scope
+- use `glab issue` for stable day-to-day issue workflows
 
-## Quick Start
+See: https://docs.gitlab.com/policy/development_stages_support/
+
+## Quick start
 
 ```bash
-# List work items in current project
-glab workitems list
+# List work items in the current project
+glab work-items list
 
-# List in a specific project
-glab workitems list --repo owner/project
+# Create a task in the current project
+glab work-items create --type task --title "Follow up on flaky pipeline"
 
-# Output as JSON
-glab workitems list --output json
+# Create a group-scoped epic
+glab work-items create --type epic --group my-group --title "Platform rewrite"
 ```
 
-## Common Workflows
+## Scope model
 
-### List Work Items
+`glab work-items` uses repository context by default, then lets you override scope explicitly:
+
+- **Current repo context** → project work items in the checked-out repository
+- `--repo owner/project` → a different project
+- `--group my-group` → group/subgroup work items
+
+This matters because some work item types are commonly project-scoped (`task`, `issue`, `incident`) while others often live at group scope (`epic`, `objective`, `key_result`).
+
+## Common workflows
+
+### List work items
 
 ```bash
-# All work items (default: open)
-glab workitems list
+# First 20 open work items in current project
+glab work-items list
 
 # Filter by type
-glab workitems list --type Task
-glab workitems list --type OKR
-glab workitems list --type KeyResult
-glab workitems list --type Epic
+glab work-items list --type epic --group gitlab-org
+glab work-items list --type issue --repo gitlab-org/cli
 
-# Filter by state
-glab workitems list --state opened
-glab workitems list --state closed
+# Closed or all states
+glab work-items list --state closed --group gitlab-org
+glab work-items list --state all --group gitlab-org
 
-# JSON for scripting
-glab workitems list --output json | python3 -c "
-import sys, json
-items = json.load(sys.stdin)
-for item in items:
-    print(f\"{item['iid']}: {item['title']} [{item['type']}]\")
-"
+# Increase page size (max 100)
+glab work-items list --per-page 50 --group gitlab-org
+
+# Cursor-based pagination
+glab work-items list --after "eyJpZCI6OTk5OX0" --group gitlab-org
+
+# JSON output for automation
+glab work-items list --output json --group gitlab-org
 ```
 
-### Use with a Specific Repo or Group
+### Create work items
+
+Use `--type` to declare the work item type explicitly.
 
 ```bash
-# Specific repo
-glab workitems list --repo mygroup/myproject
+# Create a project work item
+glab work-items create \
+  --type task \
+  --title "Audit runner costs" \
+  --description "Summarize shared-runner usage before Friday"
 
-# Group-level work items
-glab workitems list --group mygroup
+# Create a confidential incident
+glab work-items create \
+  --type incident \
+  --title "Investigate production latency spike" \
+  --confidential
+
+# Create a group-scoped epic
+glab work-items create \
+  --type epic \
+  --group my-group \
+  --title "Q3 platform migration"
+
+# JSON output for scripts
+glab work-items create --type issue --title "Backfill docs" --output json
 ```
 
-## Work Items vs Issues
+Supported upstream type values in v1.94.0 include:
+`epic`, `incident`, `issue`, `key_result`, `objective`, `requirement`, `task`, `test_case`, and `ticket`.
 
-| Feature | Issues | Work Items |
-|---|---|---|
-| Standard bug/feature tracking | ✅ | ✅ |
-| Tasks (sub-tasks) | ❌ | ✅ |
-| OKRs / Key Results | ❌ | ✅ |
-| Next-gen Epics | ❌ | ✅ |
-| CLI support | Full | `list` |
+### Delete work items
 
-Use `glab issue` for standard issue workflows. Use `glab workitems` when working with tasks, OKRs, or next-gen epics.
+```bash
+# Delete by IID in the current project
+glab work-items delete 42
+
+# Delete a group work item
+glab work-items delete 42 --group my-group
+
+# Delete from another project and return JSON
+glab work-items delete 42 --repo mygroup/myproject --output json
+```
+
+`delete` is destructive. Double-check whether the IID belongs to the intended project or group before running it.
+
+## Work items vs issues
+
+| Need | Prefer |
+|---|---|
+| Standard bug / feature issue workflow | `glab issue` |
+| Tasks, OKRs, objectives, key results, next-gen epics | `glab work-items` |
+| Stable/non-experimental issue automation | `glab issue` |
+| Group-scoped planning objects | `glab work-items --group ...` |
+
+Use `glab work-items` when the work type itself matters. Use `glab issue` when you just need standard issue lifecycle commands with the most mature CLI surface.
 
 ## Troubleshooting
 
-**"workitems: command not found":**
-- Requires glab v1.87.0+. Check with `glab version`.
+**`work-items: command not found` or docs show `workitems`:**
+- The current upstream command family is `glab work-items` with a hyphen.
+- Older `glab workitems` examples are stale.
+- Check your version with `glab version`; `work-items` coverage here assumes glab v1.94.0 guidance.
 
-**Empty results when you expect items:**
-- Work items are a separate type from issues. Items created as issues won't appear here unless they've been converted.
-- Check the GitLab UI under the project's "Plan > Work Items" sidebar.
+**Create/delete seems unavailable on your machine:**
+- Older glab versions only exposed `list`.
+- Upgrade glab if you're still on a pre-v1.94 build.
 
 **Type filter returns nothing:**
-- Not all work item types are enabled on every GitLab instance. GitLab SaaS has broader support than self-managed instances.
+- Not every GitLab instance exposes every work item type.
+- Try the correct scope (`--group` vs `--repo`) for the type you're querying.
+
+**Delete removed the wrong thing:**
+- `delete` works by IID within the selected project/group scope.
+- Re-run with explicit `--repo` or `--group` so the scope is unambiguous.
 
 ## Related Skills
 
-- `glab-issue` — Standard issue management
-- `glab-milestone` — Milestones (often used with OKRs)
-- `glab-iteration` — Sprint/iteration management
-- `glab-incident` — Incident management (a work item type)
+- `glab-issue` — Standard issue workflows
+- `glab-milestone` — Milestones often paired with OKRs and planning
+- `glab-iteration` — Sprint / iteration planning
+- `glab-incident` — Incident-specific workflows
 
-## Command Reference
+## Command reference
 
-```
-glab workitems list [--flags]
+```text
+glab work-items <command> [flags]
 
-Flags:
-  --group        Select a group/subgroup
-  --output       Format output as: text, json
-  --page         Page number
-  --per-page     Number of items per page
-  --repo         Select a repository
-  --state        Filter by state: opened, closed, all
-  --type         Filter by work item type
-  -h, --help     Show help
+glab work-items list [flags]
+  --after        Cursor for pagination
+  --group        Group/subgroup scope
+  --output       text|json
+  --per-page     Up to 100 items
+  --repo         Project scope override
+  --state        opened|closed|all
+  --type         One or more work item types
+
+glab work-items create [flags]
+  --confidential Mark the work item confidential
+  --description  Body text (use - to open editor)
+  --group        Group/subgroup scope
+  --output       text|json
+  --repo         Project scope override
+  --title        Title for the new work item
+  --type         epic|incident|issue|key_result|objective|requirement|task|test_case|ticket
+
+glab work-items delete <iid> [flags]
+  --group        Group/subgroup scope
+  --output       text|json
+  --repo         Project scope override
 ```

--- a/scripts/build-claude-skill.sh
+++ b/scripts/build-claude-skill.sh
@@ -72,7 +72,7 @@ echo "Building merged SKILL.md from $REPO_ROOT..."
 cat >> "$MERGED" <<'FRONTMATTER'
 ---
 name: gitlab-cli-skills
-description: Comprehensive GitLab CLI (glab) command reference and workflows for all GitLab operations. Use when working with merge requests, CI/CD pipelines, issues, releases, repositories, authentication, variables, labels, milestones, snippets, or any glab command. Covers 37+ sub-commands including glab mr, glab ci, glab issue, glab repo, glab release, glab variable, and more.
+description: Comprehensive GitLab CLI (glab) command reference and workflows for all GitLab operations. Use when working with merge requests, CI/CD pipelines, issues, releases, repositories, authentication, variables, labels, milestones, snippets, or any glab command. Covers 40+ sub-commands including glab mr, glab ci, glab issue, glab repo, glab release, glab variable, and more.
 dependencies:
   - glab
 ---


### PR DESCRIPTION
## Summary
- update the v1.94.0 release audit in VERSION and Claude skill metadata
- refresh glab-workitems for the renamed `glab work-items` command plus create/delete coverage
- add a new glab-orbit skill and document the new MR note / stack sync capabilities

## Testing
- bash scripts/build-claude-skill.sh
- git diff --check

Fixes #63