### PR TITLE
Update for glab v1.94.0 and v1.95.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A collection of skills for AI coding agents following the Agent Skills format. T
 - [`glab-repo`](./glab-repo)
 - [`glab-schedule`](./glab-schedule)
 - [`glab-securefile`](./glab-securefile)
+- [`glab-skills`](./glab-skills)
 - [`glab-snippet`](./glab-snippet)
 - [`glab-ssh-key`](./glab-ssh-key)
 - [`glab-stack`](./glab-stack)

--- a/SKILL.md
+++ b/SKILL.md
@@ -150,6 +150,7 @@ This skill routes to specialized sub-skills by GitLab domain:
 - `glab-attestation` - Software supply chain security
 - `glab-duo` - GitLab Duo AI assistant
 - `glab-mcp` - Model Context Protocol server for AI assistant integration (EXPERIMENTAL)
+- `glab-skills` - Install and manage bundled agent skills (EXPERIMENTAL)
 
 ## When to use glab vs web UI
 

--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,13 @@
-1.13.5
+1.13.6
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- glab v1.95.0
+  - `glab-duo`: `glab duo cli` gained `--install` and `--yes` flags.
+  - `glab-skills`: new skill coverage for experimental `glab skills install` command.
+  - `glab-repo`: `glab repo create --readme` now clones instead of using `git init` (fix).
+  - Synopsis improvements across MR, CI, issuable, and experimental subcommands (docs-only change).
 - glab v1.94.0
   - `glab-workitems`: command spelling updated to `glab work-items`; added `create` and `delete` coverage.
   - `glab-orbit`: new skill coverage for experimental Knowledge Graph / Orbit remote commands.

--- a/glab-duo/SKILL.md
+++ b/glab-duo/SKILL.md
@@ -53,6 +53,20 @@ glab duo cli
 
 Use `glab duo cli` when you specifically want the experimental GitLab Duo CLI surface that `glab` now exposes.
 
+### Installing GitLab Duo CLI (v1.95.0+)
+
+Starting in glab v1.95.0, `glab duo cli` gained `--install` and `--yes` flags:
+
+```bash
+# Install GitLab Duo CLI interactively
+glab duo cli --install
+
+# Install GitLab Duo CLI non-interactively (auto-confirm)
+glab duo cli --install --yes
+```
+
+Use `--install` to download and install the GitLab Duo CLI binaries. Use `--yes` to skip confirmation prompts during installation, which is useful for automation and CI/CD pipelines.
+
 ### Important documentation note
 
 Older guidance that recommended `glab duo update` is stale and should not be used unless a future `glab` release reintroduces that command in live help.

--- a/glab-repo/SKILL.md
+++ b/glab-repo/SKILL.md
@@ -35,9 +35,16 @@ glab repo search "keyword"
    glab repo create my-project \
      --public \
      --description "My awesome project"
+
+   # Create with README (v1.94.0+ uses clone instead of git init)
+   glab repo create my-project \
+     --public \
+     --readme
    ```
 
-2. **Clone locally:**
+   **Note:** Starting in glab v1.94.0, `glab repo create --readme` now clones the newly created repository instead of using `git init`, ensuring a clean local copy with the initial README.
+
+2. **Clone locally (if not using --readme):**
    ```bash
    glab repo clone my-username/my-project
    cd my-project

--- a/glab-skills/SKILL.md
+++ b/glab-skills/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: glab-skills
+description: Install and manage bundled agent skills for GitLab CLI. Use when installing agent skills, managing skill bundles, or setting up automated workflows. Triggers on skills, agent skills, glab skills, skill install, skill bundles.
+---
+
+# glab skills
+
+## Overview
+
+```
+
+  Install and manage bundled agent skills for GitLab CLI.
+
+  This feature is experimental and provides a way to install pre-packaged
+  skills and workflows that extend glab functionality for AI agents and
+  automation use cases.
+
+  USAGE
+
+    glab skills <command> [--flags]
+
+  COMMANDS
+
+    install [flags]  Install bundled agent skills (EXPERIMENTAL)
+
+  FLAGS
+
+    -h --help        Show help for this command.
+```
+
+## ⚠️ Experimental Feature
+
+`glab skills` is marked **EXPERIMENTAL** upstream:
+- command shape and functionality may change
+- skill bundle format is not yet stable
+- availability may vary by glab version
+- use for exploration and prototyping, not production workflows
+
+See: https://docs.gitlab.com/policy/development_stages_support/
+
+## Quick start
+
+```bash
+# View available skills commands
+glab skills --help
+
+# Install bundled agent skills
+glab skills install
+```
+
+## Common workflows
+
+### Installing bundled skills
+
+```bash
+# Install agent skills interactively
+glab skills install
+
+# Check installation status
+glab skills install --help
+```
+
+The `install` command downloads and sets up pre-packaged skill bundles designed to extend glab capabilities for automation and AI agent workflows.
+
+## Troubleshooting
+
+**`skills: command not found`:**
+- `glab skills` was added in glab v1.95.0.
+- Check your version with `glab version`; upgrade if needed.
+
+**Skills install fails or hangs:**
+- This is an experimental feature and may have rough edges.
+- Check your network connection and glab auth status.
+- Review `glab skills install --help` for any updated flags or requirements.
+
+**What skills are available?**
+- The upstream skill bundle catalog is not yet publicly documented.
+- Run `glab skills install` to see interactive prompts or available bundles.
+
+## Related Skills
+
+- `glab-duo` — GitLab Duo AI assistant integration
+- `glab-mcp` — Model Context Protocol server for AI integrations
+- `glab-auth` — Authentication required for skill installation
+
+## Command reference
+
+```text
+glab skills <command> [flags]
+
+glab skills install [flags]
+  -h --help  Show help for this command
+```


### PR DESCRIPTION
## Summary

Updates the gitlab-cli-skills repository to reflect changes in glab v1.94.0 and v1.95.0.

## Changes

### glab v1.95.0 (2026-05-08)
- **glab-duo**: Documented new `--install` and `--yes` flags for `glab duo cli`
- **glab-skills**: Added new skill coverage for experimental `glab skills install` command
- **glab-repo**: Documented fix where `glab repo create --readme` now clones instead of using `git init`
- Synopsis improvements across MR, CI, issuable, and experimental subcommands (docs-only change)

### glab v1.94.0 (already covered, verification complete)
- **glab-workitems**: Command spelling updated to `glab work-items`; added `create` and `delete` coverage
- **glab-orbit**: New skill coverage for experimental Knowledge Graph / Orbit remote commands
- **glab-mr**: Documented `glab mr note create` as the forward note flow, including `--reply`, `--file`, `--line`, and `--old-line`
- **glab-stack**: `glab stack sync` gained `--reviewer`

## Files Changed
- `VERSION`: Updated to 1.13.6 with v1.95.0 release notes
- `glab-duo/SKILL.md`: Added installation flags documentation
- `glab-skills/SKILL.md`: New skill for bundled agent skills management
- `glab-repo/SKILL.md`: Added note about --readme fix
- `SKILL.md`: Added glab-skills to utilities section
- `README.md`: Added glab-skills to available skills list

## Verification
- All changes verified by readback
- Files properly staged and committed
- Branch pushed successfully

Closes #65