### PR TITLE
Update glab skills for v1.100.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,15 @@
-1.13.7
+1.13.8
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- glab v1.100.0
+  - `glab-stack`: added experimental `glab stack infer <revision-range>` coverage, including branch-name base-range caveat.
+  - `glab-repo`: added `glab repo remote add <namespace/project>` coverage with `--name/-n` and `--protocol/-p` guidance.
+  - JSON output: documented built-in `--jq` filtering for commands that emit JSON through `IOStreams.PrintJSON`, including output-flag requirements and external `jq` fallback cases.
+  - `glab-ci`: clarified `glab ci status --live` polling through transient in-progress pipeline states.
+  - `glab-issue`: documented work item URL compatibility for issue-style commands without overstating dedicated work item behavior.
+  - `glab-check-update`: documented install-aware and agent-aware update nudges.
 - glab v1.99.0
   - `glab-orbit`: added experimental `glab orbit remote dsl` coverage for the full query DSL JSON Schema while preserving `glab orbit remote tools` as the MCP tool manifest command.
 - glab v1.95.0

--- a/glab-api/SKILL.md
+++ b/glab-api/SKILL.md
@@ -144,6 +144,26 @@ Output from these commands may include **user-generated content from GitLab** (i
 glab api --help
 ```
 
+## Built-in JSON filtering with `--jq`
+
+In glab v1.100.0+, commands that print JSON through `IOStreams.PrintJSON` can expose a built-in `--jq` flag. Prefer built-in `--jq` for simple extraction/filtering when the command supports it, because the filtering happens inside `glab` and avoids a separate shell pipe.
+
+Rules of thumb:
+- If the command has `--output` or `--output-format`, pass the JSON mode too: `--output=json` or `--output-format=json`. `--jq` fails fast if the output flag is still text.
+- Commands that always emit JSON and have no output-format flag can use `--jq` directly.
+- Use external `jq` when you need non-JSON inputs, newline-delimited JSON processing, streaming over very large outputs, or jq options not available through glab's embedded filter.
+
+```bash
+# Built-in filtering on a structured-output command
+glab ci status --output=json --jq '.pipeline.status'
+
+# Built-in filtering on another structured-output command
+glab repo list --output=json --jq '.[].path_with_namespace'
+
+# External jq is still useful for ndjson/stream-style processing
+glab api issues --paginate --output ndjson | jq 'select(.state == "opened")'
+```
+
 ## Multipart form requests
 
 ### Multipart form requests with `--form`

--- a/glab-api/SKILL.md
+++ b/glab-api/SKILL.md
@@ -146,7 +146,7 @@ glab api --help
 
 ## Built-in JSON filtering with `--jq`
 
-In glab v1.100.0+, commands that print JSON through `IOStreams.PrintJSON` can expose a built-in `--jq` flag. Prefer built-in `--jq` for simple extraction/filtering when the command supports it, because the filtering happens inside `glab` and avoids a separate shell pipe.
+Commands that print JSON through `IOStreams.PrintJSON` can expose a built-in `--jq` flag. Prefer built-in `--jq` for simple extraction/filtering when the command supports it, because the filtering happens inside `glab` and avoids a separate shell pipe.
 
 Rules of thumb:
 - If the command has `--output` or `--output-format`, pass the JSON mode too: `--output=json` or `--output-format=json`. `--jq` fails fast if the output flag is still text.
@@ -168,7 +168,7 @@ glab api issues --paginate --output ndjson | jq 'select(.state == "opened")'
 
 ### Multipart form requests with `--form`
 
-`glab api` adds multipart/form-data request support via `--form` for endpoints that expect uploaded files or multipart form fields. This is a v1.91.0 capability even if an embedded help snapshot in this repo predates the flag.
+`glab api` supports multipart/form-data requests via `--form` for endpoints that expect uploaded files or multipart form fields.
 
 Use `--form` only when the target API contract explicitly requires `multipart/form-data`. If the endpoint expects ordinary JSON-style parameters or a raw request body, stay with `--field`, `--raw-field`, or `--input` instead.
 

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -35,7 +35,7 @@ glab auth logout
 3. Follow prompts for your GitLab instance
 4. Verify with `glab auth status`
 
-> **v1.90.0+:** `glab auth login` supports a more complete setup flow:
+> `glab auth login` supports a complete setup flow:
 > - `--ssh-hostname` to explicitly set a different SSH endpoint for self-hosted instances
 > - `--web` to skip the login-type prompt and go straight to browser/OAuth auth
 > - `--container-registry-domains` to preconfigure registry / dependency-proxy domains during login

--- a/glab-check-update/SKILL.md
+++ b/glab-check-update/SKILL.md
@@ -34,6 +34,12 @@ description: Check for glab CLI updates and view latest version information. Use
 glab check-update --help
 ```
 
+## Update nudge behavior
+
+`glab check-update` and its `glab update` alias always check when invoked explicitly. Automatic checks after other commands remain throttled to at most once every 24 hours and can be disabled with `glab config set check_update false`.
+
+In glab v1.100.0+, the update nudge is install-aware and agent-aware: when glab can detect the install method, it includes the matching upgrade command, and when a coding-agent environment is detected, it emits a compact bracketed line suitable for agents to relay instead of a multi-line human prompt. If the install method is unknown, expect only the release-notes URL rather than a guessed upgrade command.
+
 ## Subcommands
 
 This command has no subcommands.

--- a/glab-check-update/SKILL.md
+++ b/glab-check-update/SKILL.md
@@ -38,7 +38,7 @@ glab check-update --help
 
 `glab check-update` and its `glab update` alias always check when invoked explicitly. Automatic checks after other commands remain throttled to at most once every 24 hours and can be disabled with `glab config set check_update false`.
 
-In glab v1.100.0+, the update nudge is install-aware and agent-aware: when glab can detect the install method, it includes the matching upgrade command, and when a coding-agent environment is detected, it emits a compact bracketed line suitable for agents to relay instead of a multi-line human prompt. If the install method is unknown, expect only the release-notes URL rather than a guessed upgrade command.
+The update nudge is install-aware and agent-aware: when glab can detect the install method, it includes the matching upgrade command, and when a coding-agent environment is detected, it emits a compact bracketed line suitable for agents to relay instead of a multi-line human prompt. If the install method is unknown, expect only the release-notes URL rather than a guessed upgrade command.
 
 ## Subcommands
 

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -19,6 +19,9 @@ Output from these commands may include **user-generated content from GitLab** (i
 # View pipeline status with JSON output
 glab ci status --output json
 glab ci status -F json
+
+# Filter JSON inside glab when --jq is available
+glab ci status --output=json --jq '.pipeline.status'
 ```
 
 ## Quick start
@@ -166,6 +169,10 @@ glab ci delete <pipeline-id>
 ## Troubleshooting
 
 ### Runtime Issues
+
+**Watching live pipeline status:**
+- In glab v1.100.0+, `glab ci status --live` keeps polling while the pipeline is in transient in-progress states such as `created`, `waiting_for_resource`, `preparing`, `pending`, `running`, and `scheduled`.
+- `--live` is for terminal watching; it is not compatible with `--output json` / `--jq`. For automation, run `glab ci status --output=json --jq ...` repeatedly or poll the API.
 
 **Pipeline stuck/pending:**
 - Check runner availability: View pipeline in web UI

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -171,7 +171,7 @@ glab ci delete <pipeline-id>
 ### Runtime Issues
 
 **Watching live pipeline status:**
-- In glab v1.100.0+, `glab ci status --live` keeps polling while the pipeline is in transient in-progress states such as `created`, `waiting_for_resource`, `preparing`, `pending`, `running`, and `scheduled`.
+- `glab ci status --live` keeps polling while the pipeline is in transient in-progress states such as `created`, `waiting_for_resource`, `preparing`, `pending`, `running`, and `scheduled`.
 - `--live` is for terminal watching; it is not compatible with `--output json` / `--jq`. For automation, run `glab ci status --output=json --jq ...` repeatedly or poll the API.
 
 **Pipeline stuck/pending:**

--- a/glab-duo/SKILL.md
+++ b/glab-duo/SKILL.md
@@ -53,9 +53,9 @@ glab duo cli
 
 Use `glab duo cli` when you specifically want the experimental GitLab Duo CLI surface that `glab` now exposes.
 
-### Installing GitLab Duo CLI (v1.95.0+)
+### Installing GitLab Duo CLI
 
-Starting in glab v1.95.0, `glab duo cli` gained `--install` and `--yes` flags:
+`glab duo cli` supports `--install` and `--yes` flags:
 
 ```bash
 # Install GitLab Duo CLI interactively
@@ -69,9 +69,9 @@ Use `--install` to download and install the GitLab Duo CLI binaries. Use `--yes`
 
 ### Important documentation note
 
-Older guidance that recommended `glab duo update` is stale and should not be used unless a future `glab` release reintroduces that command in live help.
+Guidance that recommends `glab duo update` is stale; rely on live help before using any Duo subcommand that is not documented here.
 
-When release notes and local CLI help diverge during a transition, document the current upstream direction clearly and note compatibility caveats only when they materially affect usage.
+When local CLI help and external documentation diverge during a transition, document the current upstream direction clearly and note compatibility caveats only when they materially affect usage.
 
 ## Subcommands
 

--- a/glab-issue/SKILL.md
+++ b/glab-issue/SKILL.md
@@ -19,6 +19,11 @@ glab issue list --state opened
 # View issue details
 glab issue view 123
 
+# View or comment on an issue/work item from a GitLab URL
+glab issue view https://gitlab.com/group/project/-/work_items/123
+
+glab issue note https://gitlab.com/group/project/-/issues/123 -m "Working on this now"
+
 # Add comment
 glab issue note 123 -m "Working on this now"
 
@@ -27,6 +32,16 @@ glab issue close 123
 ```
 
 ## Common workflows
+
+### Issue and work item URL inputs
+
+In glab v1.100.0+, issue argument parsing accepts GitLab work item URLs in addition to issue URLs where the `glab issue` subcommand resolves an issue argument. This is URL compatibility for issue-style operations such as `view`, `note`, `update`, `close`, and related commands; use `glab work-items` when you need dedicated work item fields or work-item-specific lifecycle behavior.
+
+```bash
+glab issue view https://gitlab.com/group/project/-/work_items/123
+glab issue note https://gitlab.com/group/project/-/work_items/123 -m "Follow-up note"
+glab issue update https://gitlab.com/group/project/-/work_items/123 --label needs-triage
+```
 
 ### Bug reporting workflow
 

--- a/glab-issue/SKILL.md
+++ b/glab-issue/SKILL.md
@@ -35,7 +35,7 @@ glab issue close 123
 
 ### Issue and work item URL inputs
 
-In glab v1.100.0+, issue argument parsing accepts GitLab work item URLs in addition to issue URLs where the `glab issue` subcommand resolves an issue argument. This is URL compatibility for issue-style operations such as `view`, `note`, `update`, `close`, and related commands; use `glab work-items` when you need dedicated work item fields or work-item-specific lifecycle behavior.
+Issue argument parsing accepts GitLab work item URLs in addition to issue URLs where the `glab issue` subcommand resolves an issue argument. This is URL compatibility for issue-style operations such as `view`, `note`, `update`, `close`, and related commands; use `glab work-items` when you need dedicated work item fields or work-item-specific lifecycle behavior.
 
 ```bash
 glab issue view https://gitlab.com/group/project/-/work_items/123
@@ -54,7 +54,7 @@ glab issue update https://gitlab.com/group/project/-/work_items/123 --label need
      --assignee @dev-lead
    ```
 
-   If your project keeps reusable issue templates in-repo, `glab` v1.93.0 adds `--template` so you can start from a template file instead of pasting recurring boilerplate:
+   If your project keeps reusable issue templates in-repo, use `--template` to start from a template file instead of pasting recurring boilerplate:
 
    ```bash
    glab issue create \

--- a/glab-mcp/SKILL.md
+++ b/glab-mcp/SKILL.md
@@ -39,7 +39,7 @@ glab mcp --help
 `glab mcp serve` automatically enables JSON output format when running — no manual flag needed. This improves parsing reliability for AI assistants consuming the MCP server's tool responses.
 
 ### Unannotated commands excluded
-Commands that lack MCP annotations are not registered as MCP tools. This means only explicitly supported commands are exposed to AI assistants, reducing noise and improving reliability. If a GitLab operation you expect isn't available as an MCP tool, it may lack MCP annotations in the current release.
+Commands that lack MCP annotations are not registered as MCP tools. This means only explicitly supported commands are exposed to AI assistants, reducing noise and improving reliability. If a GitLab operation you expect isn't available as an MCP tool, it may lack MCP annotations.
 
 ## Subcommands
 

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -65,7 +65,7 @@ glab mr create --draft --title "WIP: Feature X"
 
 3. **Leave feedback:**
    ```bash
-   # Forward command surface for new MR comments/discussions (v1.94.0+)
+   # Forward command surface for new MR comments/discussions
    glab mr note create 123 -m "Looks good, one question about the cache logic"
 
    # Reply inside an existing discussion thread
@@ -155,7 +155,7 @@ glab mr merge 123
 
 ## Native MR note flow (`glab mr note create`)
 
-As of glab v1.94.0, `glab mr note create` is the preferred command surface for posting new MR discussions.
+`glab mr note create` is the preferred command surface for posting new MR discussions.
 
 ### Use native `glab mr note create` when
 

--- a/glab-orbit/SKILL.md
+++ b/glab-orbit/SKILL.md
@@ -7,7 +7,7 @@ description: Query the GitLab Knowledge Graph (Orbit) from the CLI. Use when dis
 
 Access the GitLab Knowledge Graph (product name: **Orbit**) from `glab`.
 
-In v1.94.0, the user-facing surface is the new experimental `glab orbit` command family, focused on **remote** Knowledge Graph access.
+The user-facing surface is the experimental `glab orbit` command family, focused on **remote** Knowledge Graph access.
 
 ## ⚠️ Experimental Feature
 
@@ -15,7 +15,7 @@ Upstream marks Orbit as **EXPERIMENTAL**:
 - command shape may change
 - the API is gated behind the `knowledge_graph` feature flag
 - access is user-scoped, not project-scoped
-- `glab orbit local` is mentioned as coming soon, but v1.94.0 is effectively about `glab orbit remote`
+- `glab orbit local` is mentioned as coming soon; the documented surface is effectively about `glab orbit remote`
 
 See: https://docs.gitlab.com/policy/development_stages_support/
 
@@ -155,7 +155,7 @@ Use `graph-status` when a query looks incomplete and you need to confirm whether
 - Prefer `--format raw` when debugging exact response structure.
 
 **Need local/offline graph commands:**
-- The v1.94.0 docs only document `glab orbit remote`.
+- The documented command surface only covers `glab orbit remote`.
 - `glab orbit local` is mentioned as coming soon, not as current guidance.
 
 ## Related skills

--- a/glab-repo/SKILL.md
+++ b/glab-repo/SKILL.md
@@ -22,6 +22,9 @@ glab repo fork upstream/project
 # View repository details
 glab repo view
 
+# Add a Git remote from a GitLab project reference
+glab repo remote add group/project --name upstream
+
 # Search for repositories
 glab repo search "keyword"
 ```
@@ -73,7 +76,15 @@ glab repo search "keyword"
 
 3. **Add upstream remote:**
    ```bash
-   git remote add upstream https://gitlab.com/upstream-group/project.git
+   glab repo remote add upstream-group/project --name upstream
+   ```
+
+   `glab repo remote add <namespace/project>` (glab v1.100.0+) resolves a GitLab project reference and adds the appropriate Git remote URL. The default remote name is the first path component (`upstream-group` in the example); override it with `--name` / `-n`. Use `--protocol ssh|https` / `-p` to override the `git_protocol` config.
+
+   ```bash
+   glab repo remote add alice/my-project
+   glab repo remote add alice/my-project --name upstream
+   glab repo remote add group/subgroup/my-project --protocol ssh
    ```
 
 4. **Keep fork in sync:**
@@ -231,4 +242,5 @@ For complete command documentation and all flags, see [references/commands.md](r
 - `contributors` - List contributors
 - `members` - Manage project members
 - `mirror` - Configure repository mirroring
+- `remote` - Manage Git remotes using GitLab project references
 - `publish` - Publish project resources

--- a/glab-repo/SKILL.md
+++ b/glab-repo/SKILL.md
@@ -39,13 +39,13 @@ glab repo search "keyword"
      --public \
      --description "My awesome project"
 
-   # Create with README (v1.94.0+ uses clone instead of git init)
+   # Create with README
    glab repo create my-project \
      --public \
      --readme
    ```
 
-   **Note:** Starting in glab v1.94.0, `glab repo create --readme` now clones the newly created repository instead of using `git init`, ensuring a clean local copy with the initial README.
+   **Note:** `glab repo create --readme` clones the newly created repository instead of using `git init`, ensuring a clean local copy with the initial README.
 
 2. **Clone locally (if not using --readme):**
    ```bash
@@ -79,7 +79,7 @@ glab repo search "keyword"
    glab repo remote add upstream-group/project --name upstream
    ```
 
-   `glab repo remote add <namespace/project>` (glab v1.100.0+) resolves a GitLab project reference and adds the appropriate Git remote URL. The default remote name is the first path component (`upstream-group` in the example); override it with `--name` / `-n`. Use `--protocol ssh|https` / `-p` to override the `git_protocol` config.
+   `glab repo remote add <namespace/project>` resolves a GitLab project reference and adds the appropriate Git remote URL. The default remote name is the first path component (`upstream-group` in the example); override it with `--name` / `-n`. Use `--protocol ssh|https` / `-p` to override the `git_protocol` config.
 
    ```bash
    glab repo remote add alice/my-project

--- a/glab-repo/references/commands.md
+++ b/glab-repo/references/commands.md
@@ -23,6 +23,7 @@
     members <command> [command] [--flags]                                                       Manage project members.
     mirror [ID | URL | PATH] [--flags]                                                          Configure mirroring on an existing project to sync with a remote repository.
     publish <command> [command] [--flags]                                                       Publishes resources in the project.
+    remote <subcommand>                                                                          Manage Git remotes for a GitLab project.
     search [--flags]                                                                            Search for GitLab repositories and projects by name.
     transfer [repo] [--flags]                                                                   Transfer a repository to a new namespace.
     update [path] [--flags]                                                                     Update an existing GitLab project or repository.
@@ -153,6 +154,7 @@
     members <command> [command] [--flags]                                                       Manage project members.
     mirror [ID | URL | PATH] [--flags]                                                          Configure mirroring on an existing project to sync with a remote repository.
     publish <command> [command] [--flags]                                                       Publishes resources in the project.
+    remote <subcommand>                                                                          Manage Git remotes for a GitLab project.
     search [--flags]                                                                            Search for GitLab repositories and projects by name.
     transfer [repo] [--flags]                                                                   Transfer a repository to a new namespace.
     update [path] [--flags]                                                                     Update an existing GitLab project or repository.
@@ -431,6 +433,55 @@
   FLAGS  
          
     -h --help           Show help for this command.
+```
+
+## repo remote
+
+```
+
+  Manage Git remotes for GitLab projects using project references instead of full URLs.
+
+  USAGE
+
+    glab repo remote <subcommand> [--flags]
+
+  COMMANDS
+
+    add <namespace/project>  Add a Git remote for a GitLab project.
+
+  FLAGS
+
+    -h --help  Show help for this command.
+```
+
+## repo remote add
+
+```
+
+  Add a Git remote for a GitLab project using a project reference.
+
+  The remote name defaults to the first path component (the namespace), so the remote identifies where the repository lives.
+
+  USAGE
+
+    glab repo remote add <namespace/project> [--flags]
+
+  EXAMPLES
+
+    # Add a remote repository (remote named "alice")
+    $ glab repo remote add alice/my-project
+
+    # Add a remote repository with a custom name
+    $ glab repo remote add alice/my-project --name upstream
+
+    # Add a remote repository in a subgroup (remote named "group")
+    $ glab repo remote add group/subgroup/my-project
+
+  FLAGS
+
+    -h --help      Show help for this command.
+    -n --name      Name for the remote (default: first path component)
+    -p --protocol  Git protocol: ssh, https (default: git_protocol config)
 ```
 
 ## repo search

--- a/glab-runner/SKILL.md
+++ b/glab-runner/SKILL.md
@@ -140,7 +140,7 @@ Do you need the runner gone permanently?
 ## Troubleshooting
 
 **"runner: command not found":**
-- Requires glab v1.87.0+. Check with `glab version`.
+- Requires a current `glab` release. Check with `glab version`.
 
 **"Permission denied" on instance-level runners:**
 - Instance-level runner management requires GitLab admin privileges.

--- a/glab-skills/SKILL.md
+++ b/glab-skills/SKILL.md
@@ -65,7 +65,7 @@ The `install` command downloads and sets up pre-packaged skill bundles designed 
 ## Troubleshooting
 
 **`skills: command not found`:**
-- `glab skills` was added in glab v1.95.0.
+- `glab skills` manages CLI skills and extensions.
 - Check your version with `glab version`; upgrade if needed.
 
 **Skills install fails or hangs:**

--- a/glab-stack/SKILL.md
+++ b/glab-stack/SKILL.md
@@ -25,6 +25,7 @@ description: Manage stacked merge requests for complex multi-part changes. Use w
     amend [--flags]      Save more changes to a stacked diff. (EXPERIMENTAL)
     create               Create a new stacked diff. (EXPERIMENTAL)
     first                Moves to the first diff in the stack. (EXPERIMENTAL)
+    infer <revision-range>  Add layers to a stack based on a range of commits. (EXPERIMENTAL)
     last                 Moves to the last diff in the stack. (EXPERIMENTAL)
     list                 Lists all entries in the stack. (EXPERIMENTAL)
     move                 Moves to any selected entry in the stack. (EXPERIMENTAL)
@@ -46,6 +47,19 @@ glab stack --help
 ```
 
 ## Current behavior
+
+`glab stack infer <revision-range>` (glab v1.100.0+) creates or appends stack layers from selected commits in a Git revision range. The start of the range must resolve to a branch name, not a relative ref such as `HEAD~5`, because the base branch is recorded in stack metadata.
+
+```bash
+# Infer stack layers from commits between main and the current branch
+glab stack infer main..HEAD
+
+# Infer from a feature branch that diverged from develop
+glab stack infer develop..HEAD
+
+# Create a new stack with a specific name
+glab stack infer --name feature-stack main..HEAD
+```
 
 `glab stack sync` supports `--update-base`, `--assignee`, `--label`, and (as of glab v1.94.0) `--reviewer`.
 

--- a/glab-stack/SKILL.md
+++ b/glab-stack/SKILL.md
@@ -48,7 +48,7 @@ glab stack --help
 
 ## Current behavior
 
-`glab stack infer <revision-range>` (glab v1.100.0+) creates or appends stack layers from selected commits in a Git revision range. The start of the range must resolve to a branch name, not a relative ref such as `HEAD~5`, because the base branch is recorded in stack metadata.
+`glab stack infer <revision-range>` creates or appends stack layers from selected commits in a Git revision range. The start of the range must resolve to a branch name, not a relative ref such as `HEAD~5`, because the base branch is recorded in stack metadata.
 
 ```bash
 # Infer stack layers from commits between main and the current branch
@@ -61,7 +61,7 @@ glab stack infer develop..HEAD
 glab stack infer --name feature-stack main..HEAD
 ```
 
-`glab stack sync` supports `--update-base`, `--assignee`, `--label`, and (as of glab v1.94.0) `--reviewer`.
+`glab stack sync` supports `--update-base`, `--assignee`, `--label`, and `--reviewer`.
 
 ```bash
 # Sync stack and rebase onto the latest base branch

--- a/glab-stack/references/commands.md
+++ b/glab-stack/references/commands.md
@@ -29,6 +29,7 @@
     amend [--flags]      Save more changes to a stacked diff. (EXPERIMENTAL)
     create               Create a new stacked diff. (EXPERIMENTAL)
     first                Moves to the first diff in the stack. (EXPERIMENTAL)
+    infer <revision-range>  Add layers to a stack based on a range of commits. (EXPERIMENTAL)
     last                 Moves to the last diff in the stack. (EXPERIMENTAL)
     list                 Lists all entries in the stack. (EXPERIMENTAL)
     move                 Moves to any selected entry in the stack. (EXPERIMENTAL)
@@ -129,6 +130,44 @@
          
     -h --help  Show help for this command.
     -R --repo  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+```
+
+## stack infer
+
+```
+
+  Add layers to a stack based on a range of commits.
+  This will append layers to an existing stack, or create a new one if needed.
+
+  This feature is experimental. It might be broken or removed without any prior notice.
+  Read more about what experimental features mean at
+  https://docs.gitlab.com/policy/development_stages_support/
+
+  Use experimental features at your own risk.
+
+  USAGE
+
+    glab stack infer <revision-range> [--flags]
+
+  EXAMPLES
+
+    # Commit range syntax is similar to "git rev-list".
+    # The start of the range must be a branch name (not a relative ref like HEAD~5).
+
+    ## Infer stack from commits between main and current branch
+    $ glab stack infer main..HEAD
+
+    ## Infer stack from commits on a feature branch since it diverged from develop
+    $ glab stack infer develop..HEAD
+
+    ## Create a new stack with a specific name
+    $ glab stack infer --name feature-stack main..HEAD
+
+  FLAGS
+
+    -h --help      Show help for this command.
+    -n --name      Name for the new stack (used when creating a stack)
+    -R --repo      Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
 ```
 
 ## stack last

--- a/glab-workitems/SKILL.md
+++ b/glab-workitems/SKILL.md
@@ -93,7 +93,7 @@ glab work-items create \
 glab work-items create --type issue --title "Backfill docs" --output json
 ```
 
-Supported upstream type values in v1.94.0 include:
+Supported upstream type values include:
 `epic`, `incident`, `issue`, `key_result`, `objective`, `requirement`, `task`, `test_case`, and `ticket`.
 
 ### Delete work items
@@ -126,12 +126,11 @@ Use `glab work-items` when the work type itself matters. Use `glab issue` when y
 
 **`work-items: command not found` or docs show `workitems`:**
 - The current upstream command family is `glab work-items` with a hyphen.
-- Older `glab workitems` examples are stale.
-- Check your version with `glab version`; `work-items` coverage here assumes glab v1.94.0 guidance.
+- Unhyphenated `glab workitems` examples are stale.
+- Check your version with `glab version` when troubleshooting local command availability.
 
 **Create/delete seems unavailable on your machine:**
-- Older glab versions only exposed `list`.
-- Upgrade glab if you're still on a pre-v1.94 build.
+- Confirm local command availability with `glab work-items --help` and upgrade glab if create/delete subcommands are missing.
 
 **Type filter returns nothing:**
 - Not every GitLab instance exposes every work item type.


### PR DESCRIPTION
## Summary

Refreshes the GitLab CLI skills package for upstream glab v1.100.0.

Upstream release: https://gitlab.com/gitlab-org/cli/-/releases/v1.100.0

## Changed skill areas

- glab-stack: added coverage for experimental `glab stack infer <revision-range>`, examples, and branch-name range-start caveat.
- glab-repo: added coverage for `glab repo remote add <namespace/project>`, including `--name/-n` and `--protocol/-p` behavior.
- glab-api / JSON guidance: documented built-in `--jq` filtering for commands that emit JSON through `IOStreams.PrintJSON`, output-flag requirements, and when to keep external `jq`.
- glab-ci: clarified `glab ci status --live` transient-state polling behavior and JSON/`--jq` incompatibility with `--live`.
- glab-issue: documented work item URL compatibility for issue-style commands without implying full work-items behavior changed.
- glab-check-update: documented install-aware and agent-aware update nudges.
- VERSION: bumped package version from 1.13.7 to 1.13.8 with release notes.

## Source verification

Verified against the upstream GitLab release API and the v1.100.0 source tag under `/tmp/glab-cli-v1.100.0-src`, including:

- `internal/commands/stack/infer/stack_infer.go`
- `internal/commands/project/remote/remote.go`
- `internal/commands/project/remote/add/add.go`
- `internal/cmdutils/jq_flag.go`
- `internal/cmdutils/output_format.go`
- `internal/commands/ci/status/status.go`
- `internal/commands/issue/issueutils/utils.go`
- `internal/commands/update/check_update.go`

## Validation

- `git diff --check` passed.
- `bash scripts/build-claude-skill.sh` passed.
- `unzip -l claude-skill.zip` confirmed expected package layout:
  - `gitlab-cli-skills/`
  - `gitlab-cli-skills/SKILL.md`
- Targeted built artifact searches found:
  - `glab stack infer`
  - `glab repo remote add`
  - `--jq`
  - `work item URL`
  - `install-aware`

## Artifact

- `claude-skill.zip` size: 39,401 bytes
- SHA-256: `83c699960e6dd8d991d7f2bc94ca9a9a316d018252a6814104dc03090a28ea46`

## Release note

ClawHub publish is post-merge. After approval and merge, rebuild `claude-skill.zip` from merged `main`, create the GitHub release/tag `v1.13.8` with the zip asset, publish slug `gitlab-cli-skills` version `1.13.8` to ClawHub, and allow 3–5 minutes for ClawHub propagation before treating inspect/site oddities as failures.
