### PR TITLE
docs: refresh glab skills for v1.102.0

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -146,6 +146,7 @@ This skill routes to specialized sub-skills by GitLab domain:
 - `glab-help` - Command help and documentation
 - `glab-version` - Version information
 - `glab-check-update` - Update checker
+- `glab-whatsnew` - Release notes since the last viewed or post-upgrade baseline
 - `glab-changelog` - Changelog generation
 - `glab-attestation` - Software supply chain security
 - `glab-duo` - GitLab Duo AI assistant

--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,19 @@
-1.13.8
+1.13.9
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- glab v1.102.0
+  - `glab-repo`: added `glab repo prune` coverage for deleting local branches whose merge requests are merged, including `--dry-run`, `--yes`, `--exclude`, and `--merged` caveats.
+  - `glab-whatsnew`: added new skill coverage for `glab whatsnew` release-note discovery and post-upgrade review workflows.
+  - `glab-skills`: documented `list` and `update` subcommands plus installed-skill update notifications.
+  - `glab-api`: documented Duo workflow/session environment headers and URL-encoded magic placeholder substitutions.
+  - `glab-config`: documented canonical `config set` validation and `GLAB_NO_PROMPT` replacing deprecated `NO_PROMPT`.
+- glab v1.101.0
+  - `glab-ci`: documented `glab ci cancel job --force` for forced job cancellation.
+  - `glab-mr`: documented `glab mr note create --resolvable=false` for non-blocking automation/status notes.
+  - `glab-orbit`: added `glab orbit setup` guided onboarding coverage and noted current `orbit local` support.
+  - `glab-stack`: documented `glab stack sync --skip-mr-creation`.
 - glab v1.100.0
   - `glab-stack`: added experimental `glab stack infer <revision-range>` coverage, including branch-name base-range caveat.
   - `glab-repo`: added `glab repo remote add <namespace/project>` coverage with `--name/-n` and `--protocol/-p` guidance.

--- a/glab-api/SKILL.md
+++ b/glab-api/SKILL.md
@@ -52,6 +52,10 @@ Output from these commands may include **user-generated content from GitLab** (i
   - If the value starts with `@`, the rest of the value is interpreted as a
     filename to read the value from. Pass `-` to read from standard input.
 
+  Placeholder substitutions in endpoints and fields are URL-encoded before the
+  request is sent. This matters for project/group paths containing `/` and for
+  automation that previously encoded placeholders manually.
+
   For GraphQL requests, all fields other than `query` and `operationName` are
   interpreted as GraphQL variables.
 
@@ -143,6 +147,19 @@ Output from these commands may include **user-generated content from GitLab** (i
 ```bash
 glab api --help
 ```
+
+## Automation headers and placeholder encoding
+
+`glab api` forwards Duo workflow/session environment identifiers as GitLab headers when present:
+
+```bash
+DUO_WORKFLOW_WORKFLOW_ID=... glab api projects/:fullpath
+GITLAB_DUO_SESSION_ID=... glab api projects/:fullpath
+```
+
+These become `X-Gitlab-Duo-Workflow-Id` and `X-Gitlab-Duo-Session-Id` respectively. Do not invent or spoof these values; preserve them only when the surrounding GitLab Duo workflow/session supplied them.
+
+Magic placeholders such as `:fullpath`, `:namespace`, `:repo`, and `:branch` are URL-encoded by `glab` during substitution. Prefer placeholders over manual string interpolation when possible, and avoid double-encoding values that `glab` will substitute.
 
 ## Built-in JSON filtering with `--jq`
 

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -161,6 +161,17 @@ glab ci run --variables KEY1=value1 --variables KEY2=value2
 glab ci cancel <pipeline-id>
 ```
 
+**Cancel running jobs:**
+```bash
+# Cancel one or more jobs by ID
+glab ci cancel job <job-id> [<job-id>...]
+
+# Force cancellation when ordinary cancellation does not stop the job promptly
+glab ci cancel job <job-id> --force
+```
+
+Use `--force` sparingly: it is intended for stuck or otherwise hard-to-cancel jobs, not as the default cancellation path.
+
 **Delete old pipeline:**
 ```bash
 glab ci delete <pipeline-id>

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -82,6 +82,16 @@ A plain `source ~/.config/openclaw/env/gitlab-<agent>.env` updates the current s
 
 Use distinct GitLab bot/service accounts when agents need distinct visible identities. Multiple PATs on one GitLab user still act as that same user.
 
+## Non-interactive prompts and config validation
+
+Use `GLAB_NO_PROMPT=1` for non-interactive automation that must fail instead of prompting. Upstream docs now prefer the `GLAB_`-prefixed name; older `NO_PROMPT` is deprecated and should not be used in new scripts.
+
+```bash
+GLAB_NO_PROMPT=1 glab repo prune --dry-run
+```
+
+`glab config set` validates keys against the canonical config schema. If a set operation fails, check the spelling and whether the setting is host-scoped (`--host`) or global (`--global`) rather than forcing an unknown key into the config file.
+
 ## Common Settings
 
 ```bash

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -68,6 +68,9 @@ glab mr create --draft --title "WIP: Feature X"
    # Forward command surface for new MR comments/discussions
    glab mr note create 123 -m "Looks good, one question about the cache logic"
 
+   # Automation/status update that should not create a resolvable thread
+   glab mr note create 123 -m "Build status: green" --resolvable=false
+
    # Reply inside an existing discussion thread
    glab mr note create 123 --reply abc12345 -m "Good catch — updated"
 
@@ -163,6 +166,9 @@ glab mr merge 123
 # New top-level discussion/comment
 glab mr note create 123 -m "Please add a regression test"
 
+# Non-resolvable note for automation/status output
+glab mr note create 123 -m "Build status: green" --resolvable=false
+
 # Reply to an existing discussion thread
 glab mr note create 123 --reply abc12345 -m "Fixed in the latest push"
 
@@ -182,8 +188,10 @@ glab mr note create 123 --file src/app.ts --old-line 37 -m "Why was this guard r
 Flag rules worth remembering from the upstream help/docs:
 - `--reply` targets an existing discussion thread instead of starting a new one.
 - `--reply` accepts a full discussion ID or a unique prefix of at least 8 characters.
+- By default, new top-level notes are created as resolvable discussion threads. Use `--resolvable=false` for bot/status comments that should not block projects requiring all threads to be resolved.
 - `--line` and `--old-line` require `--file` and cannot be used together.
 - `--file`, `--reply`, and `--unique` are mutually exclusive.
+- `--resolvable=false` cannot be combined with `--reply`, `--file`, `--line`, or `--old-line`.
 - Omit both `--line` and `--old-line` when you want a file-level diff comment.
 
 ### Keep the helper/script path when

--- a/glab-orbit/SKILL.md
+++ b/glab-orbit/SKILL.md
@@ -7,7 +7,7 @@ description: Query the GitLab Knowledge Graph (Orbit) from the CLI. Use when dis
 
 Access the GitLab Knowledge Graph (product name: **Orbit**) from `glab`.
 
-The user-facing surface is the experimental `glab orbit` command family, focused on **remote** Knowledge Graph access.
+The user-facing surface is the experimental `glab orbit` command family, covering **remote** Knowledge Graph access, guided setup, and the Orbit local CLI wrapper.
 
 ## ⚠️ Experimental Feature
 
@@ -15,7 +15,7 @@ Upstream marks Orbit as **EXPERIMENTAL**:
 - command shape may change
 - the API is gated behind the `knowledge_graph` feature flag
 - access is user-scoped, not project-scoped
-- `glab orbit local` is mentioned as coming soon; the documented surface is effectively about `glab orbit remote`
+- `glab orbit local` downloads/runs a local Orbit CLI binary and may have separate host/platform constraints
 
 See: https://docs.gitlab.com/policy/development_stages_support/
 
@@ -24,6 +24,9 @@ See: https://docs.gitlab.com/policy/development_stages_support/
 ```bash
 # First: confirm the service is available for your user
 glab orbit remote status
+
+# Guided onboarding: verify access, install the Orbit agent skill, and install local CLI
+glab orbit setup
 
 # Discover the graph model
 glab orbit remote schema
@@ -38,7 +41,7 @@ glab orbit remote schema User Project MergeRequest
 
 The upstream docs strongly point to a discovery-first flow:
 
-1. `glab orbit remote status` — verify Orbit is enabled and reachable
+1. `glab orbit setup` or `glab orbit remote status` — verify Orbit is enabled and reachable
 2. `glab orbit remote schema` — inspect the ontology (entities, edges, properties)
 3. `glab orbit remote dsl` — inspect the authoritative JSON Schema for the query DSL
 4. `glab orbit remote tools` — inspect the MCP tool manifest when integrating with agents/tools
@@ -47,6 +50,27 @@ The upstream docs strongly point to a discovery-first flow:
 That order matters because `schema` and `dsl` are the source of truth for what the graph exposes and what request bodies are valid; `tools` is still useful for MCP/agent integration metadata.
 
 ## Common workflows
+
+### 0) Guided setup
+
+```bash
+# Interactive onboarding: checks access, prompts to install the skill, prompts to install local CLI
+glab orbit setup
+
+# Non-interactive setup: accept all prompts
+glab orbit setup --yes
+
+# Verify reachability only
+glab orbit setup --skip-skill --skip-local
+
+# Install the Orbit skill at user scope instead of in the current repo
+glab orbit setup --global
+
+# Refresh the skill and update the local CLI binary in place
+glab orbit setup --upgrade
+```
+
+Use `--path <path>` for a custom skill install directory, `--hostname <host>` to verify a specific GitLab host, and `--skip-skill` / `--skip-local` when you only want part of the onboarding.
 
 ### 1) Check service health
 
@@ -155,8 +179,8 @@ Use `graph-status` when a query looks incomplete and you need to confirm whether
 - Prefer `--format raw` when debugging exact response structure.
 
 **Need local/offline graph commands:**
-- The documented command surface only covers `glab orbit remote`.
-- `glab orbit local` is mentioned as coming soon, not as current guidance.
+- Use `glab orbit setup` to install the local CLI binary, then `glab orbit local` to run it.
+- Keep remote discovery (`status`, `schema`, `dsl`, `tools`) in the workflow so generated local queries still match the server-side graph model.
 
 ## Related skills
 
@@ -189,4 +213,16 @@ glab orbit remote graph-status [flags]
   --hostname      Target GitLab host
   --namespace-id  Group ID
   --project-id    Project ID
+
+glab orbit setup [flags]
+  --global      Install the Orbit skill at user scope (`~/.agents/skills/`)
+  --hostname    GitLab hostname to verify
+  --path        Custom Orbit skill install directory
+  --skip-local  Skip the local CLI binary install step
+  --skip-skill  Skip the agent-skill install step
+  --upgrade     Re-fetch the skill and update the local CLI binary in place
+  --yes         Skip every confirmation prompt
+
+glab orbit local [command] [flags]
+  Runs the Orbit local CLI; setup/download may happen before first use.
 ```

--- a/glab-repo/SKILL.md
+++ b/glab-repo/SKILL.md
@@ -25,6 +25,10 @@ glab repo view
 # Add a Git remote from a GitLab project reference
 glab repo remote add group/project --name upstream
 
+# Prune local branches whose MRs have been merged
+glab repo prune --dry-run
+glab repo prune --yes
+
 # Search for repositories
 glab repo search "keyword"
 ```
@@ -135,6 +139,29 @@ glab repo transfer my-project --target-namespace new-group
 glab repo delete group/project
 ```
 
+### Local branch pruning
+
+`glab repo prune` deletes **local** Git branches whose GitLab merge requests have been merged. It never deletes remote branches on GitLab, and it skips protected branches, the default branch, and the branch currently checked out.
+
+```bash
+# Preview branches that would be deleted
+glab repo prune --dry-run
+
+# Delete branches after confirmation
+glab repo prune
+
+# Delete without confirmation after reviewing the dry run
+glab repo prune --yes
+
+# Exclude additional branches by exact name or glob; comma-separate or repeat
+glab repo prune --exclude wip-*,demo-branch
+
+# Faster local-Git detection; misses squash/rebase merges that are not fast-forward ancestry
+glab repo prune --merged
+```
+
+Prefer the default GitLab-backed mode for correctness: it queries merge requests for each local branch and handles squash/rebase merge cases better than plain `git branch --merged`. Use `--merged` only when the faster fast-forward-only check is acceptable.
+
 ### Member management
 
 **List collaborators:**
@@ -243,4 +270,5 @@ For complete command documentation and all flags, see [references/commands.md](r
 - `members` - Manage project members
 - `mirror` - Configure repository mirroring
 - `remote` - Manage Git remotes using GitLab project references
+- `prune` - Delete local branches whose GitLab merge requests are merged
 - `publish` - Publish project resources

--- a/glab-skills/SKILL.md
+++ b/glab-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-skills
-description: Install and manage bundled agent skills for GitLab CLI. Use when installing agent skills, managing skill bundles, or setting up automated workflows. Triggers on skills, agent skills, glab skills, skill install, skill bundles.
+description: Install, list, and update bundled agent skills for GitLab CLI. Use when installing agent skills, checking available bundled skills, updating installed glab skills, managing skill bundles, or setting up automated workflows. Triggers on skills, agent skills, glab skills, skill install, skill update, skill bundles.
 ---
 
 # glab skills
@@ -11,21 +11,26 @@ description: Install and manage bundled agent skills for GitLab CLI. Use when in
 
   Install and manage bundled agent skills for GitLab CLI.
 
-  This feature is experimental and provides a way to install pre-packaged
-  skills and workflows that extend glab functionality for AI agents and
-  automation use cases.
+  Skills follow the Agent Skills specification and work with
+  any compatible agent, including GitLab Duo Agent Platform, Claude Code, Codex,
+  and Gemini CLI.
+
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
 
   USAGE
 
-    glab skills <command> [--flags]
+    glab skills <command> [command] [--flags]
 
   COMMANDS
 
-    install [flags]  Install bundled agent skills (EXPERIMENTAL)
+    install [name] [--flags]  Install glab's bundled agent skills. (EXPERIMENTAL)
+    list                      List the available bundled agent skills. (EXPERIMENTAL)
+    update [name] [--flags]   Update installed agent skills to the current shipped version. (EXPERIMENTAL)
 
   FLAGS
 
-    -h --help        Show help for this command.
+    -h --help                 Show help for this command.
 ```
 
 ## ⚠️ Experimental Feature
@@ -46,21 +51,36 @@ glab skills --help
 
 # Install bundled agent skills
 glab skills install
+
+# List bundled skills
+glab skills list
+
+# Update installed bundled skills to the current glab-shipped version
+glab skills update
 ```
 
 ## Common workflows
 
-### Installing bundled skills
+### Installing, listing, and updating bundled skills
 
 ```bash
 # Install agent skills interactively
 glab skills install
 
-# Check installation status
-glab skills install --help
+# Install a named bundled skill when supported by the shipped catalog
+glab skills install <name>
+
+# List available bundled skills
+glab skills list
+
+# Update all installed bundled skills
+glab skills update
+
+# Update one installed bundled skill
+glab skills update <name>
 ```
 
-The `install` command downloads and sets up pre-packaged skill bundles designed to extend glab capabilities for automation and AI agent workflows.
+The `install` command sets up pre-packaged skill bundles designed to extend glab capabilities for automation and AI agent workflows. Newer `glab` versions also notify when installed bundled skills have updates available; use `glab skills update` to refresh them to the current version shipped with the installed CLI.
 
 ## Troubleshooting
 
@@ -68,14 +88,13 @@ The `install` command downloads and sets up pre-packaged skill bundles designed 
 - `glab skills` manages CLI skills and extensions.
 - Check your version with `glab version`; upgrade if needed.
 
-**Skills install fails or hangs:**
+**Skills install/update fails or hangs:**
 - This is an experimental feature and may have rough edges.
 - Check your network connection and glab auth status.
-- Review `glab skills install --help` for any updated flags or requirements.
+- Review `glab skills install --help`, `glab skills list`, and `glab skills update --help` for any updated flags or requirements.
 
 **What skills are available?**
-- The upstream skill bundle catalog is not yet publicly documented.
-- Run `glab skills install` to see interactive prompts or available bundles.
+- Run `glab skills list` to see the bundled catalog for your installed `glab` version.
 
 ## Related Skills
 
@@ -88,6 +107,11 @@ The `install` command downloads and sets up pre-packaged skill bundles designed 
 ```text
 glab skills <command> [flags]
 
-glab skills install [flags]
+glab skills install [name] [flags]
+  -h --help  Show help for this command
+
+glab skills list
+
+glab skills update [name] [flags]
   -h --help  Show help for this command
 ```

--- a/glab-stack/SKILL.md
+++ b/glab-stack/SKILL.md
@@ -61,11 +61,14 @@ glab stack infer develop..HEAD
 glab stack infer --name feature-stack main..HEAD
 ```
 
-`glab stack sync` supports `--update-base`, `--assignee`, `--label`, and `--reviewer`.
+`glab stack sync` supports `--update-base`, `--assignee`, `--label`, `--reviewer`, and `--skip-mr-creation`.
 
 ```bash
 # Sync stack and rebase onto the latest base branch
 glab stack sync --update-base
+
+# Sync/push existing stack work without opening MRs for branches that do not have one yet
+glab stack sync --skip-mr-creation
 
 # Sync stack and set MR metadata during submission
 glab stack sync --assignee @owner --reviewer @reviewer --label backend
@@ -76,6 +79,8 @@ glab stack sync --reviewer user1,user2
 ```
 
 Use `--update-base` when the base branch (for example `main`) has moved and you want to rebase the entire stack before pushing.
+
+Use `--skip-mr-creation` when you want to push amended stack branches and clean up merged/closed entries but intentionally avoid opening new merge requests for stack layers that do not have one yet.
 
 Use `--assignee`, `--reviewer`, and `--label` when you want `glab stack sync` to submit the stack's merge requests with ownership and routing metadata in the same step.
 

--- a/glab-whatsnew/SKILL.md
+++ b/glab-whatsnew/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: glab-whatsnew
+description: View GitLab CLI release notes with glab whatsnew. Use when checking what changed after upgrading glab, reviewing release notes since a baseline version, or asking what's new in the GitLab CLI. Triggers on whatsnew, what's new, release notes, glab upgrade notes, glab changelog since.
+---
+
+# glab whatsnew
+
+View GitLab CLI release notes from the terminal.
+
+## Quick start
+
+```bash
+# Show release notes since the last viewed/post-upgrade baseline, capped at 10 releases
+glab whatsnew
+
+# Show notes for the latest published release
+glab whatsnew --latest
+
+# Show notes for a specific release
+glab whatsnew v1.102.0
+
+# Show notes for every release after a baseline
+glab whatsnew --since v1.100.0
+```
+
+## When to use
+
+Use `glab whatsnew` after upgrading `glab` or before updating automation that depends on command behavior. It is the quickest CLI-native path for inspecting upstream release notes without opening a browser.
+
+## Behavior notes
+
+- With no arguments, `glab whatsnew` shows releases published since the last time you ran `whatsnew` or saw the post-upgrade banner.
+- The implicit history is capped at the most recent 10 releases.
+- Use `--since <version>` for deterministic automation or review work where you need an explicit baseline.
+- Use `--latest` when you only care about the latest published release.
+
+## Agent workflow
+
+```bash
+# Review all releases newer than the skill repo's last processed glab baseline
+glab whatsnew --since v1.100.0
+
+# Then inspect command help for any relevant new/changed command surfaces
+glab repo prune --help
+glab mr note create --help
+glab stack sync --help
+```
+
+Do not treat release-note prose alone as a contract. For skill updates, verify changed command surfaces with `glab <command> --help` or upstream docs/source before editing guidance.
+
+## Command reference
+
+```text
+glab whatsnew [version] [--flags]
+
+Flags:
+  --latest   Show release notes for the latest published release only
+  --since    Show release notes for every release newer than this version
+  -h --help  Show help for this command
+```


### PR DESCRIPTION
## Upstream version/source

- GitLab CLI `glab` v1.102.0
- Canonical GitLab release API/source: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest
- Release notes reviewed:
  - https://gitlab.com/gitlab-org/cli/-/releases/v1.101.0
  - https://gitlab.com/gitlab-org/cli/-/releases/v1.102.0

## Summary of CLI changes reviewed

From v1.101.0:
- `glab ci cancel job` gained `--force`.
- `glab mr note create` gained `--resolvable` for non-resolvable automation/status notes.
- `glab orbit setup` guided onboarding was added; `orbit local` is now part of the help surface.
- `glab stack sync` gained `--skip-mr-creation`.

From v1.102.0:
- `glab repo prune` was added for pruning local branches whose GitLab MRs are merged.
- `glab whatsnew` was added for release-note review and post-upgrade banners.
- `glab skills` gained `list` / `update` and installed-skill update notifications.
- `glab api` forwards Duo workflow/session headers and URL-encodes magic placeholder substitutions.
- Docs/config surface now prefers `GLAB_NO_PROMPT` and notes canonical `config set` validation.

## Generated skill changes

- Bumped package metadata to `1.13.9` and recorded glab v1.101.0/v1.102.0 release notes in `VERSION`.
- Updated `glab-ci`, `glab-mr`, `glab-orbit`, `glab-stack`, `glab-repo`, `glab-skills`, `glab-api`, and `glab-config` guidance for the new/changed command surfaces.
- Added new `glab-whatsnew` skill and linked it from the top-level router skill.
- No repo-local refresh automation, scheduler scripts, or GitHub Actions were added.

## Validation

```text
$ scripts/build-claude-skill.sh
✅ Done.
   Merged:  42 sub-skills + top-level
   Lines:       5105
   Size:      156968 bytes
   Output:  /Users/steven/.hermes/workspaces/cli-skills-refresh/gitlab-cli-skills/claude-skill.zip

$ unzip -t claude-skill.zip
No errors detected in compressed data of claude-skill.zip.

$ python3 frontmatter sanity check
frontmatter_check: ok
```

Please review before merge, especially the new `glab-whatsnew` routing and the `glab repo prune` safety wording.
