### PR TITLE
feat: refresh glab v1.103.0 skills

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -108,6 +108,7 @@ This skill routes to specialized sub-skills by GitLab domain:
 - `glab-iteration` - Sprint/iteration management
 - `glab-label` - Label management and organization
 - `glab-release` - Software releases and versioning
+- `glab-packages` - Project package registry listing and filtering
 
 **Authentication & Config:**
 - `glab-auth` - Login, logout, Docker registry auth
@@ -134,6 +135,7 @@ This skill routes to specialized sub-skills by GitLab domain:
 **Advanced:**
 - `glab-api` - Direct REST API calls
 - `glab-cluster` - Kubernetes cluster integration
+- `glab-container-registry` - Container registry repositories and tags
 - `glab-deploy-key` - Deploy keys for automation
 - `glab-orbit` - GitLab Knowledge Graph / Orbit discovery, schema inspection, and remote query workflows (EXPERIMENTAL)
 - `glab-quick-actions` - GitLab slash command quick actions for batching state changes

--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,10 @@
-1.13.10
+1.13.11
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.11
+  - glab v1.103.0 refresh: added `glab-container-registry` coverage for repository/tag list, view, delete, and bulk tag cleanup; added `glab-packages` coverage for package registry listing/filtering; updated `glab-stack` for interactive `switch` and `--no-verify` on `amend`/`save`.
 - v1.13.10
   - Corrective release version for ClawHub publication because ClawHub already had an immutable stale `1.13.9` entry before the GitHub v1.13.9 release was published.
   - Skill content remains the glab v1.102.0 refresh below.

--- a/glab-container-registry/SKILL.md
+++ b/glab-container-registry/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: glab-container-registry
+description: Manage GitLab container registry repositories and tags with glab. Use when listing, viewing, or deleting container registry repositories/tags, cleaning old image tags, inspecting tag metadata, or using glab container-registry commands. Triggers on container registry, registry repository, registry tags, image tags, glab container-registry.
+---
+
+# glab container-registry
+
+Manage GitLab container registry repositories and tags from the CLI.
+
+> Added in glab v1.103.0. Repository IDs come from registry repository list/view output, not from Git repository project IDs.
+
+## Common workflows
+
+```bash
+# List registry repositories for the current project
+glab container-registry repository list
+
+# List repositories for another project
+glab container-registry repository list -R gitlab-org/cli
+
+# List repositories for a group
+glab container-registry repository list --group gitlab-org
+
+# Include tag counts/tags in project repository output
+glab container-registry repository list --include-tags-count --include-tags
+
+# JSON output for automation
+glab container-registry repository list --output json --jq '.[].id'
+```
+
+## Repository commands
+
+```bash
+# View a registry repository
+glab container-registry repository view <repository-id>
+
+# Include tags in the repository response
+glab container-registry repository view <repository-id> --include-tags
+
+# Delete a repository and all images/tags published to it (destructive)
+glab container-registry repository delete <repository-id>
+glab container-registry repository delete <repository-id> --yes
+```
+
+Aliases: `repository ls`, `repository show`, and `repository del`.
+
+## Tag commands
+
+```bash
+# List tags for a registry repository
+glab container-registry tag list <repository-id>
+
+# List tags for a repository in another project
+glab container-registry tag list <repository-id> -R owner/repo
+
+# Include digest, size, and creation time for each tag
+glab container-registry tag list <repository-id> --details
+
+# View a specific tag
+glab container-registry tag view <repository-id> <tag-name>
+
+# Delete one tag (destructive)
+glab container-registry tag delete <repository-id> <tag-name>
+glab container-registry tag delete <repository-id> <tag-name> --yes
+```
+
+Aliases: `tag ls`, `tag show`, and `tag del`.
+
+## Bulk tag cleanup
+
+Bulk deletion is scheduled asynchronously by GitLab. Matching tags may remain visible until the background deletion job completes.
+
+```bash
+# Schedule tags matching a regex for deletion
+glab container-registry tag delete <repository-id> \
+  --name-regex-delete '^release-.*' \
+  --yes
+
+# Delete old tags while keeping the 10 most recent matching tags
+glab container-registry tag delete <repository-id> \
+  --name-regex-delete '.*' \
+  --keep-n 10 \
+  --older-than 30d \
+  --yes
+
+# Keep tags matching a regex during bulk deletion
+glab container-registry tag delete <repository-id> \
+  --name-regex-delete '.*' \
+  --name-regex-keep '^stable$|^latest$' \
+  --yes
+```
+
+Bulk flags:
+- `--name-regex-delete <regex>` — tag names to delete.
+- `--name-regex-keep <regex>` — tag names to keep.
+- `--keep-n <n>` — keep latest N matching tags.
+- `--older-than <duration>` — delete tags older than durations like `7d` or `1month`.
+
+## Safety notes
+
+- Treat repository/tag delete commands as destructive; omit `--yes` unless the target IDs and regexes have been reviewed.
+- Use `--output json` and `--jq` for scripts instead of parsing tables.
+- Use `-R/--repo` whenever running outside the target project's checkout.
+
+## Reference
+
+See [references/commands.md](references/commands.md) for command synopsis and flags.

--- a/glab-container-registry/references/commands.md
+++ b/glab-container-registry/references/commands.md
@@ -1,0 +1,94 @@
+# glab container-registry help
+
+> Command reference captured from upstream glab v1.103.0 generated documentation.
+
+## container-registry repository list
+
+```text
+glab container-registry repository list [flags]
+
+Aliases: ls
+
+Options:
+  -g, --group string          List container registry repositories for a group.
+      --include-tag-details   Fetch digest, size, and creation time for included tags. Makes one API call per tag. Project JSON output only. Implies --include-tags.
+      --include-tags          Include tags in the response. Project repositories only.
+      --include-tags-count    Include the number of tags in the response. Project repositories only. (default true)
+      --jq string             Filter JSON output with a jq expression.
+  -F, --output string         Format output as: text, json. (default "text")
+  -p, --page int              Page number. (default 1)
+  -P, --per-page int          Number of items to list per page. (default 30)
+  -R, --repo string           Select another repository.
+```
+
+## container-registry repository view
+
+```text
+glab container-registry repository view <repository-id> [flags]
+
+Aliases: show
+
+Options:
+      --include-tags         Include tags in the response.
+      --include-tags-count   Include the number of tags in the response. (default true)
+      --jq string            Filter JSON output with a jq expression.
+  -F, --output string        Format output as: text, json. (default "text")
+  -R, --repo string          Select another repository.
+```
+
+## container-registry repository delete
+
+```text
+glab container-registry repository delete <repository-id> [flags]
+
+Aliases: del
+
+Options:
+  -y, --yes   Skip the confirmation prompt.
+  -R, --repo string   Select another repository.
+```
+
+## container-registry tag list
+
+```text
+glab container-registry tag list <repository-id> [flags]
+
+Aliases: ls
+
+Options:
+      --details         Fetch digest, size, and creation time for each tag. Makes one API call per tag.
+      --jq string       Filter JSON output with a jq expression.
+  -F, --output string   Format output as: text, json. (default "text")
+  -p, --page int        Page number. (default 1)
+  -P, --per-page int    Number of items to list per page. (default 30)
+  -R, --repo string     Select another repository.
+```
+
+## container-registry tag view
+
+```text
+glab container-registry tag view <repository-id> <tag-name> [flags]
+
+Aliases: show
+
+Options:
+      --jq string       Filter JSON output with a jq expression.
+  -F, --output string   Format output as: text, json. (default "text")
+  -R, --repo string     Select another repository.
+```
+
+## container-registry tag delete
+
+```text
+glab container-registry tag delete <repository-id> [<tag-name>] [flags]
+
+Aliases: del
+
+Options:
+      --keep-n int                 Keep the latest N matching tags. Bulk deletion only; scheduled asynchronously.
+      --name-regex-delete string   Regular expression for tag names to delete. Bulk deletion only; scheduled asynchronously.
+      --name-regex-keep string     Regular expression for tag names to keep. Bulk deletion only; scheduled asynchronously.
+      --older-than string          Delete tags older than the given duration, such as 7d or 1month. Bulk deletion only; scheduled asynchronously.
+  -y, --yes                        Skip the confirmation prompt.
+  -R, --repo string                Select another repository.
+```

--- a/glab-packages/SKILL.md
+++ b/glab-packages/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: glab-packages
+description: List GitLab project package registry packages with glab. Use when inspecting packages, filtering GitLab package registry entries by package name/type, paginating package registry results, or using glab packages commands. Triggers on GitLab packages, package registry, glab packages, npm packages in GitLab, Maven packages in GitLab.
+---
+
+# glab packages
+
+List packages in a GitLab project's package registry.
+
+> Added in glab v1.103.0. The initial command group provides `list` / `ls` for project package registries.
+
+## Quick start
+
+```bash
+# List all packages in the current project
+glab packages list
+
+# Alias
+glab packages ls
+
+# List packages from another project
+glab packages list -R owner/repo
+```
+
+## Filtering
+
+```bash
+# Filter by package name substring
+glab packages list --name my-package
+
+# Filter by package type
+glab packages list --package-type npm
+glab packages list --package-type maven
+glab packages list --package-type generic
+```
+
+Supported package types from glab help:
+
+```text
+composer, conan, debian, generic, golang, helm, maven, npm, nuget, pypi, terraform_module
+```
+
+## Pagination and automation
+
+```bash
+# Select a page and page size
+glab packages list --page 2 --per-page 10
+
+# JSON output filtering is available through the global --jq support on this command
+glab packages list --jq '.[].name'
+```
+
+Use `-R/--repo` when running outside the target project's Git checkout. Prefer structured output/`--jq` for scripts rather than parsing text tables.
+
+## Reference
+
+See [references/commands.md](references/commands.md) for command synopsis and flags.

--- a/glab-packages/references/commands.md
+++ b/glab-packages/references/commands.md
@@ -1,0 +1,40 @@
+# glab packages help
+
+> Command reference captured from upstream glab v1.103.0 generated documentation.
+
+## packages list
+
+```text
+List packages in a project's package registry.
+
+glab packages list [flags]
+
+Aliases: ls
+
+Options:
+      --jq string             Filter JSON output with a jq expression.
+  -n, --name string           Filter packages by name (substring match).
+      --package-type string   Package type composer, conan, debian, generic, golang, helm, maven, npm, nuget, pypi, terraform_module
+  -p, --page int              Page number. (default 1)
+  -P, --per-page int          Number of items to list per page. (default 30)
+  -R, --repo string           Select another repository.
+```
+
+Examples:
+
+```bash
+# List all packages in the current project
+glab packages list
+
+# Use the alias
+glab packages ls
+
+# Filter by package name
+glab packages list --name my-package
+
+# List a specific page with a custom page size
+glab packages list --page 2 --per-page 10
+
+# List packages from another project
+glab packages list -R owner/repo
+```

--- a/glab-stack/SKILL.md
+++ b/glab-stack/SKILL.md
@@ -33,7 +33,7 @@ description: Manage stacked merge requests for complex multi-part changes. Use w
     prev                 Moves to the previous diff in the stack. (EXPERIMENTAL)
     reorder              Reorder a stack of merge requests. (EXPERIMENTAL)
     save [--flags]       Save your progress within a stacked diff. (EXPERIMENTAL)
-    switch <stack-name>  Switch between stacks. (EXPERIMENTAL)
+    switch [stack-name]  Switch between stacks. (EXPERIMENTAL)
     sync                 Sync and submit progress on a stacked diff. (EXPERIMENTAL)
   FLAGS
     -h --help            Show help for this command.
@@ -83,6 +83,10 @@ Use `--update-base` when the base branch (for example `main`) has moved and you 
 Use `--skip-mr-creation` when you want to push amended stack branches and clean up merged/closed entries but intentionally avoid opening new merge requests for stack layers that do not have one yet.
 
 Use `--assignee`, `--reviewer`, and `--label` when you want `glab stack sync` to submit the stack's merge requests with ownership and routing metadata in the same step.
+
+`glab stack switch` can now be run without a stack name to choose interactively from all stacks. Pass the stack name for non-interactive automation.
+
+`glab stack amend` and `glab stack save` support `--no-verify` to bypass local `pre-commit` and `commit-msg` hooks for the underlying Git commit. Treat it like `git commit --no-verify`: use only when the skipped hooks are understood and intentionally bypassed.
 
 ## Subcommands
 

--- a/glab-stack/references/commands.md
+++ b/glab-stack/references/commands.md
@@ -74,6 +74,7 @@
     -d --description  A description of the change
     -h --help         Show help for this command.
     -m --message      Alias for the description flag
+       --no-verify    Bypass the pre-commit and commit-msg hooks of git-commit(1).
     -R --repo         Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
 ```
 
@@ -359,6 +360,7 @@
     -d --description  Description of the change.
     -h --help         Show help for this command.
     -m --message      Alias for the description flag.
+       --no-verify    Bypass the pre-commit and commit-msg hooks of git-commit(1).
     -R --repo         Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
 ```
 
@@ -367,7 +369,7 @@
 ```
 
   Switch between stacks to work on another stack created with "glab stack create".                                      
-  To see the list of all stacks, check the `.git/stacked/` directory.                                                   
+  When stack-name is omitted, choose from the list of all stacks.                                                       
                                                                                                                         
   This feature is experimental. It might be broken or removed without any prior notice.                                 
   Read more about what experimental features mean at                                                                    
@@ -378,10 +380,11 @@
          
   USAGE  
          
-    glab stack switch <stack-name> [--flags]  
+    glab stack switch [stack-name] [--flags]  
             
   EXAMPLES  
             
+    $ glab stack switch                       
     $ glab stack switch <stack-name>          
          
   FLAGS  


### PR DESCRIPTION
## Upstream

- CLI/source: GitLab CLI `glab`
- Upstream version: `v1.103.0`
- Source: https://gitlab.com/gitlab-org/cli/-/releases/v1.103.0
- Also re-reviewed the previously corrected unprocessed window from `v1.100.0` through `v1.102.0`; current `main` already contains the needed v1.101/v1.102 skill coverage.

## CLI changes reviewed

User-facing v1.103.0 changes relevant to skills:

- New `glab container-registry` command group:
  - `repository list/view/delete`
  - `tag list/view/delete`
  - bulk tag cleanup flags (`--name-regex-delete`, `--name-regex-keep`, `--keep-n`, `--older-than`)
- New `glab packages list` / `glab packages ls` command for project package registry listings.
- `glab stack switch` now supports omitted `stack-name` for interactive selection.
- `glab stack amend` and `glab stack save` gained `--no-verify`.

Non-skill-impacting items reviewed: Windows ARM64 binary, MR checkout conflict handling, MCP structuredContent fix, Orbit Linux packaging fix, CI/release/dependency/maintenance changes.

## Skill changes

- Added `glab-container-registry` skill and command reference.
- Added `glab-packages` skill and command reference.
- Updated top-level routing in `SKILL.md`.
- Updated `glab-stack` skill/reference for interactive `switch` and `--no-verify` on `amend`/`save`.
- Bumped skill package version metadata to `1.13.11`.

## Validation

```text
./scripts/build-claude-skill.sh
✅ Done.
   Merged:  44 sub-skills + top-level
   Lines:       5277
   Size:      162060 bytes
   Output:  /Users/steven/.hermes/workspaces/cli-skills-refresh/gitlab-cli-skills/claude-skill.zip

python frontmatter sanity check
checked 44 sub-skill frontmatters

unzip -t claude-skill.zip
No errors detected in compressed data of claude-skill.zip.
```

Vince: please review before merge.