### PR TITLE
docs: refresh glab v1.104.0 packages skill

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,10 @@
-1.13.12
+1.13.13
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.13
+  - glab v1.104.0 refresh: updated `glab-packages` for the new `glab packages upload` / `ul` command, including required `--name` and `--version`, optional `--filename`, and `-R/--repo` targeting.
 - v1.13.12
   - Packaging/distribution fix: moved the top-level orchestrator skill into `gitlab-cli-skills/SKILL.md` so `npx skills add` discovers the orchestrator plus all standalone `glab-*` sub-skills instead of stopping at a root `SKILL.md`.
   - Added relative links from the orchestrator to each sub-skill and bundled referenced helper scripts inside their consuming skill directories so selective installs keep documented `scripts/...` workflows usable.

--- a/gitlab-cli-skills/SKILL.md
+++ b/gitlab-cli-skills/SKILL.md
@@ -109,7 +109,7 @@ standalone skill in a sibling directory; open its `SKILL.md` for full details.
 - [`glab-iteration`](../glab-iteration/SKILL.md) - Sprint/iteration management
 - [`glab-label`](../glab-label/SKILL.md) - Label management and organization
 - [`glab-release`](../glab-release/SKILL.md) - Software releases and versioning
-- [`glab-packages`](../glab-packages/SKILL.md) - Project package registry listing and filtering
+- [`glab-packages`](../glab-packages/SKILL.md) - Project package registry listing, filtering, and generic package uploads
 
 **Authentication & Config:**
 - [`glab-auth`](../glab-auth/SKILL.md) - Login, logout, Docker registry auth

--- a/glab-packages/SKILL.md
+++ b/glab-packages/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: glab-packages
-description: List GitLab project package registry packages with glab. Use when inspecting packages, filtering GitLab package registry entries by package name/type, paginating package registry results, or using glab packages commands. Triggers on GitLab packages, package registry, glab packages, npm packages in GitLab, Maven packages in GitLab.
+description: List and upload GitLab project package registry packages with glab. Use when inspecting packages, filtering GitLab package registry entries by package name/type, paginating package registry results, uploading generic package files, or using glab packages commands. Triggers on GitLab packages, package registry, glab packages, npm packages in GitLab, Maven packages in GitLab, generic package upload.
 ---
 
 # glab packages
 
-List packages in a GitLab project's package registry.
+List packages in a GitLab project's package registry and upload files as generic packages.
 
-> Added in glab v1.103.0. The initial command group provides `list` / `ls` for project package registries.
+> Added in glab v1.103.0. `glab packages list` / `ls` lists project package registries. glab v1.104.0 added `glab packages upload` / `ul` for generic package uploads.
 
 ## Quick start
 
@@ -20,6 +20,9 @@ glab packages ls
 
 # List packages from another project
 glab packages list -R owner/repo
+
+# Upload a file as a generic package version
+glab packages upload ./build/app.zip --name my-package --version 1.0.0
 ```
 
 ## Filtering
@@ -51,6 +54,21 @@ glab packages list --jq '.[].name'
 ```
 
 Use `-R/--repo` when running outside the target project's Git checkout. Prefer structured output/`--jq` for scripts rather than parsing text tables.
+
+## Upload generic package files
+
+```bash
+# Upload a local file under its original filename
+glab packages upload ./build/app.zip --name my-package --version 1.0.0
+
+# Store the uploaded file under a different package filename
+glab packages upload ./build/app.zip --name my-package --version 1.0.0 --filename release.zip
+
+# Alias and explicit target project
+glab packages ul ./build/app.zip -n my-package --version 1.0.0 -R owner/repo
+```
+
+Upload stores the file as a **generic** package in the target project's package registry. `--name` and `--version` are required; `--filename` defaults to the local file basename. Use `-R/--repo` for uploads outside the target project checkout.
 
 ## Reference
 

--- a/glab-packages/references/commands.md
+++ b/glab-packages/references/commands.md
@@ -1,6 +1,6 @@
 # glab packages help
 
-> Command reference captured from upstream glab v1.103.0 generated documentation.
+> Command reference captured from upstream glab v1.104.0 generated documentation.
 
 ## packages list
 
@@ -37,4 +37,33 @@ glab packages list --page 2 --per-page 10
 
 # List packages from another project
 glab packages list -R owner/repo
+```
+
+## packages upload
+
+```text
+Upload a file to a project's package registry.
+
+glab packages upload <file> --name <package> --version <version> [flags]
+
+Aliases: ul
+
+Options:
+      --filename string   Name to store the file under. Defaults to the local file name.
+  -n, --name string       Name of the package.
+  -v, --version string    Version of the package.
+  -R, --repo string       Select another repository.
+```
+
+Examples:
+
+```bash
+# Upload a file as version 1.0.0 of package 'my-package'
+glab packages upload ./build/app.zip --name my-package --version 1.0.0
+
+# Store the file under a different name
+glab packages upload ./build/app.zip --name my-package --version 1.0.0 --filename release.zip
+
+# Use the 'ul' alias and upload to another project
+glab packages ul ./build/app.zip -n my-package --version 1.0.0 -R owner/repo
 ```


### PR DESCRIPTION
## Upstream source

- CLI: GitLab CLI (`glab`)
- Upstream release: v1.104.0
- Source: https://gitlab.com/gitlab-org/cli/-/releases/v1.104.0
- Canonical release API checked: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest

## CLI changes reviewed

Relevant v1.104.0 changes:
- `glab packages upload` / `glab packages ul` was added for uploading local files as generic packages.
- Required flags: `--name/-n` and `--version/-v`.
- Optional `--filename` stores the package file under a different name.
- Inherits `-R/--repo` for targeting another project.

Other v1.104.0 changes reviewed but not reflected in skill output because they do not require operator guidance changes here: Duo snap-confinement warning, generated GitLab Docs navigation block, dependency/template/test-maintenance updates, and upstream threaded-reply docs wording.

## Generated skill changes

- Updated `glab-packages` frontmatter/overview to cover package uploads.
- Added quick-start and workflow examples for `glab packages upload` / `ul`.
- Refreshed `glab-packages/references/commands.md` to v1.104.0 with upload synopsis, flags, alias, and examples.
- Updated orchestrator routing text and `VERSION` release notes.

## Validation

- `bash scripts/build-claude-skill.sh`
  - Built merged Claude skill package with 44 sub-skills + top-level.
  - Output: `claude-skill.zip`
  - Lines: 5301
  - Size: 164799 bytes
- Python zip sanity check verified `gitlab-cli-skills/SKILL.md` exists in the zip and contains the new `glab packages upload` guidance.
- Changed paths are limited to skill/package content and metadata; no repo-local automation or GitHub Actions were added.

Please review, Vince. Do not merge until you are satisfied with the skill content.
