### PR TITLE
docs: refresh glab v1.105.0 orbit skill

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,10 @@
-1.13.13
+1.13.14
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.14
+  - glab v1.105.0 refresh: updated `glab-orbit` for the Orbit remote flag rename from `--format` to `--response-format` on `query` and `graph-status`, and documented the `graph-status --jq` option. Also noted that deprecation warnings now route to stderr, which does not require skill content changes beyond keeping stdout examples parse-safe.
 - v1.13.13
   - glab v1.104.0 refresh: updated `glab-packages` for the new `glab packages upload` / `ul` command, including required `--name` and `--version`, optional `--filename`, and `-R/--repo` targeting.
 - v1.13.12

--- a/glab-orbit/SKILL.md
+++ b/glab-orbit/SKILL.md
@@ -133,12 +133,13 @@ glab orbit remote query ./query.json
 cat ./query.json | glab orbit remote query -
 
 # Force structured JSON for jq pipelines
-glab orbit remote query --format raw ./query.json
+glab orbit remote query --response-format raw ./query.json
 ```
 
 Notes:
 - Default output is `llm`, which is compact and agent-friendly.
-- Use `--format raw` when you want structured JSON for further processing.
+- Use `--response-format raw` when you want structured JSON for further processing.
+- `--format` / `-f` are deprecated compatibility aliases; update scripts to `--response-format` so deprecation warnings stay out of automation logs.
 - The query body shape is defined by `glab orbit remote dsl`, not by guesswork.
 
 ### 6) Check indexing progress
@@ -152,7 +153,7 @@ glab orbit remote graph-status --project-id 278964
 glab orbit remote graph-status --namespace-id 9970
 
 # Compact output for agents
-glab orbit remote graph-status --full-path gitlab-org/gitlab --format llm
+glab orbit remote graph-status --full-path gitlab-org/gitlab --response-format llm
 ```
 
 Use `graph-status` when a query looks incomplete and you need to confirm whether the relevant project/group has been indexed yet.
@@ -176,7 +177,7 @@ Use `graph-status` when a query looks incomplete and you need to confirm whether
 **Query body keeps failing validation:**
 - Fetch the current DSL schema with `glab orbit remote dsl`.
 - Fetch the ontology with `glab orbit remote schema`.
-- Prefer `--format raw` when debugging exact response structure.
+- Prefer `--response-format raw` when debugging exact response structure.
 
 **Need local/offline graph commands:**
 - Use `glab orbit setup` to install the local CLI binary, then `glab orbit local` to run it.
@@ -204,15 +205,16 @@ glab orbit remote tools [flags]
   --hostname    Target GitLab host
 
 glab orbit remote query [file|-] [flags]
-  --format      llm|raw (default: llm)
-  --hostname    Target GitLab host
+  --hostname         Target GitLab host
+  --response-format  llm|raw (default: llm)
 
 glab orbit remote graph-status [flags]
-  --format        raw|llm (default: raw)
-  --full-path     Project/group full path
-  --hostname      Target GitLab host
-  --namespace-id  Group ID
-  --project-id    Project ID
+  --full-path        Project/group full path
+  --hostname         Target GitLab host
+  --jq               Filter JSON output with a jq expression
+  --namespace-id     Group ID
+  --project-id       Project ID
+  --response-format  raw|llm (default: raw)
 
 glab orbit setup [flags]
   --global      Install the Orbit skill at user scope (`~/.agents/skills/`)


### PR DESCRIPTION
## Upstream version/source

- GitLab CLI (`glab`) upstream release: v1.105.0
- Canonical release API: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest
- Release page: https://gitlab.com/gitlab-org/cli/-/releases/v1.105.0
- Compared against the prior processed skill release for glab v1.104.0; also rechecked the corrective v1.101.0/v1.102.0/v1.103.0/v1.104.0 release sequence per the Hermes cron instruction.

## Relevant CLI changes

- `glab orbit remote query`: `--format` was renamed to `--response-format`; the old `--format`/`-f` path remains as a deprecated compatibility alias.
- `glab orbit remote graph-status`: same `--format` to `--response-format` rename, plus generated docs now expose `--jq string` in the options list.
- Deprecation/diagnostic warnings are now routed to stderr instead of stdout, which matters for stdout-parsing automation but does not require broad skill rewrites.
- Other release item: API client dependency update only; no skill content impact.

## Generated skill/package changes

- Updated `glab-orbit/SKILL.md` examples and command reference to use `--response-format` for `query` and `graph-status`.
- Added a compatibility note that `--format`/`-f` are deprecated aliases and scripts should move to `--response-format`.
- Added `graph-status --jq` to the Orbit command reference.
- Bumped `VERSION` to 1.13.14 with release-history notes.

## Validation

```text
$ bash scripts/build-claude-skill.sh
✅ Done.
   Merged:  44 sub-skills + top-level
   Lines:       5303
   Size:      165070 bytes
   Output:  /Users/steven/.hermes/workspaces/cli-skills-refresh/gitlab-cli-skills/claude-skill.zip

$ python3 zip/frontmatter sanity checks
merged lines: 5303
orbit response-format refs: 7
old orbit command --format refs: 0
frontmatter sanity OK
```

Vince: please review before merge. This PR was created by the Hermes-owned CLI skills refresh cron; it does not add repo-local refresh automation, workflows, scheduler scripts, or refresh engine code.
