### PR TITLE
docs: refresh glab skills for v1.106.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,10 @@
-1.13.14
+1.13.15
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.15
+  - glab v1.106.0 refresh: updated `glab-packages` for the new `glab packages download` / `dl` and `glab packages delete` / `rm` commands, including checksum verification/overwrite behavior and deletion-by-ID safety guidance. Updated `glab-stack` for `glab stack amend --reword` message-only amendments.
 - v1.13.14
   - glab v1.105.0 refresh: updated `glab-orbit` for the Orbit remote flag rename from `--format` to `--response-format` on `query` and `graph-status`, and documented the `graph-status --jq` option. Also noted that deprecation warnings now route to stderr, which does not require skill content changes beyond keeping stdout examples parse-safe.
 - v1.13.13

--- a/glab-packages/SKILL.md
+++ b/glab-packages/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: glab-packages
-description: List and upload GitLab project package registry packages with glab. Use when inspecting packages, filtering GitLab package registry entries by package name/type, paginating package registry results, uploading generic package files, or using glab packages commands. Triggers on GitLab packages, package registry, glab packages, npm packages in GitLab, Maven packages in GitLab, generic package upload.
+description: List, upload, download, and delete GitLab project package registry packages with glab. Use when inspecting packages, filtering GitLab package registry entries by package name/type, paginating package registry results, uploading or downloading generic package files, deleting packages, or using glab packages commands. Triggers on GitLab packages, package registry, glab packages, npm packages in GitLab, Maven packages in GitLab, generic package upload, generic package download, delete package.
 ---
 
 # glab packages
 
-List packages in a GitLab project's package registry and upload files as generic packages.
+List packages in a GitLab project's package registry, upload/download generic package files, and delete package registry entries by ID.
 
-> Added in glab v1.103.0. `glab packages list` / `ls` lists project package registries. glab v1.104.0 added `glab packages upload` / `ul` for generic package uploads.
+> Added in glab v1.103.0. `glab packages list` / `ls` lists project package registries. glab v1.104.0 added `glab packages upload` / `ul` for generic package uploads. glab v1.106.0 added `glab packages download` / `dl` for generic package downloads and `glab packages delete` / `rm` for package deletion by numeric ID.
 
 ## Quick start
 
@@ -23,6 +23,12 @@ glab packages list -R owner/repo
 
 # Upload a file as a generic package version
 glab packages upload ./build/app.zip --name my-package --version 1.0.0
+
+# Download a generic package file
+glab packages download --name my-package --version 1.0.0 --filename app.zip
+
+# Delete a package by numeric ID after listing packages
+glab packages delete 12345 --yes
 ```
 
 ## Filtering
@@ -69,6 +75,45 @@ glab packages ul ./build/app.zip -n my-package --version 1.0.0 -R owner/repo
 ```
 
 Upload stores the file as a **generic** package in the target project's package registry. `--name` and `--version` are required; `--filename` defaults to the local file basename. Use `-R/--repo` for uploads outside the target project checkout.
+
+## Download generic package files
+
+```bash
+# Download a package file to the current directory
+glab packages download --name my-package --version 1.0.0 --filename app.zip
+
+# Download into a directory, keeping the original file name
+glab packages download -n my-package --version 1.0.0 --filename app.zip --path ./downloads/
+
+# Download to an exact path, renaming the file
+glab packages download -n my-package --version 1.0.0 --filename app.zip --path ./downloads/renamed.zip
+
+# Skip checksum verification only when you intentionally accept the integrity risk
+glab packages download -n my-package --version 1.0.0 --filename app.zip --no-verify
+
+# Alias, overwrite an existing target, and explicit project targeting
+glab packages dl -n my-package --version 1.0.0 --filename app.zip --force -R owner/repo
+```
+
+Download is limited to **generic** package files and requires `--name`, `--version`, and `--filename`. By default glab verifies the downloaded file against registry checksum metadata and fails if the destination already exists. Use `--path` for a directory or exact output filename, `--force` to overwrite, and `--no-verify` only when checksum verification is intentionally bypassed.
+
+## Delete packages
+
+```bash
+# Find the package ID first
+glab packages list --name my-package
+
+# Delete by numeric package ID; prompts for confirmation
+glab packages delete 12345
+
+# Skip confirmation for automation after independently confirming the ID
+glab packages delete 12345 --yes
+
+# Alias
+glab packages rm 12345
+```
+
+Delete operates on a package's numeric ID, not the package name/version. Use `glab packages list` (preferably with JSON/`--jq` in scripts) to identify the ID, then pass `--yes` only when the target package has been verified.
 
 ## Reference
 

--- a/glab-packages/references/commands.md
+++ b/glab-packages/references/commands.md
@@ -1,6 +1,74 @@
 # glab packages help
 
-> Command reference captured from upstream glab v1.104.0 generated documentation.
+> Command reference captured from upstream glab v1.106.0 generated documentation.
+
+## packages delete
+
+```text
+Delete a package from a project's package registry.
+
+glab packages delete <id> [flags]
+
+Aliases: rm
+
+Options:
+  -y, --yes             Skip the confirmation prompt.
+  -R, --repo string     Select another repository.
+```
+
+Examples:
+
+```bash
+# Delete a package by ID
+glab packages delete 1
+
+# Skip the confirmation prompt
+glab packages delete 1 -y
+
+# Use the 'rm' alias
+glab packages rm 1
+```
+
+## packages download
+
+```text
+Download a file from a project's package registry.
+
+glab packages download --name <package> --version <version> --filename <file> [flags]
+
+Aliases: dl
+
+Options:
+      --filename string   Name of the file within the package to download.
+      --force             Overwrite the target file if it already exists.
+  -n, --name string       Name of the package.
+      --no-verify         Do not verify the checksum of the downloaded file. Warning: when enabled, this setting allows the download of files that are corrupt or tampered with.
+  -p, --path string       Directory to save the file in (keeps its original name) or a full file path to rename it. Defaults to the original name in the current directory.
+      --version string    Version of the package.
+  -R, --repo string       Select another repository.
+```
+
+Examples:
+
+```bash
+# Download a package file to the current directory
+glab packages download --name my-package --version 1.0.0 --filename app.zip
+
+# Download into a directory, keeping the original file name
+glab packages download -n my-package --version 1.0.0 --filename app.zip --path ./downloads/
+
+# Download to an exact path, renaming the file
+glab packages download -n my-package --version 1.0.0 --filename app.zip --path ./downloads/renamed.zip
+
+# Download without verifying the checksum
+glab packages download -n my-package --version 1.0.0 --filename app.zip --no-verify
+
+# Overwrite an existing file
+glab packages download -n my-package --version 1.0.0 --filename app.zip --force
+
+# Use the 'dl' alias and target another project
+glab packages dl -n my-package --version 1.0.0 --filename app.zip -R owner/repo
+```
 
 ## packages list
 

--- a/glab-stack/SKILL.md
+++ b/glab-stack/SKILL.md
@@ -86,6 +86,12 @@ Use `--assignee`, `--reviewer`, and `--label` when you want `glab stack sync` to
 
 `glab stack switch` can now be run without a stack name to choose interactively from all stacks. Pass the stack name for non-interactive automation.
 
+`glab stack amend` supports `--reword` to update only the stacked commit message without staging files. It cannot be combined with file arguments or `--all`; pass `-m/--message` or `-d/--description`, or let glab open the editor.
+
+```bash
+glab stack amend --reword -m "updated commit message"
+```
+
 `glab stack amend` and `glab stack save` support `--no-verify` to bypass local `pre-commit` and `commit-msg` hooks for the underlying Git commit. Treat it like `git commit --no-verify`: use only when the skipped hooks are understood and intentionally bypassed.
 
 ## Subcommands

--- a/glab-stack/references/commands.md
+++ b/glab-stack/references/commands.md
@@ -65,16 +65,25 @@
             
   EXAMPLES  
             
-    $ glab stack amend modifiedfile                     
-    $ glab stack amend . -m "fixed a function"          
-    $ glab stack amend newfile -d "forgot to add this"  
+    # Amend diff with currently staged changes
+    $ glab stack amend -m "Fix a function"
+    # Add specified file to staged changes and amend diff
+    $ glab stack amend newfile -m "forgot to add this"
+    # Add all tracked files to staged changes and amend diff
+    $ glab stack amend -a -m "fixed a function in exisiting file"
+    # Add all tracked and untracked files to staged changes and amend diff
+    $ glab stack amend . -m "refactored file into new files"
+    # Reword the commit message without adding any files
+    $ glab stack amend --reword -m "updated commit message"
          
   FLAGS  
          
+    -a --all          Automatically stage modified and deleted tracked files.
     -d --description  A description of the change
     -h --help         Show help for this command.
     -m --message      Alias for the description flag
        --no-verify    Bypass the pre-commit and commit-msg hooks of git-commit(1).
+       --reword       Only update the commit message without staging any files.
     -R --repo         Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
 ```
 


### PR DESCRIPTION
## Upstream source

- GitLab CLI (`glab`) v1.106.0
- Canonical release API: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest
- Release page: https://gitlab.com/gitlab-org/cli/-/releases/v1.106.0

## Upstream CLI changes reviewed

v1.106.0 includes relevant user-facing CLI changes:

- `glab packages delete <id>` / `glab packages rm <id>` for deleting package registry entries by numeric ID, with `--yes` for non-interactive confirmation bypass.
- `glab packages download` / `glab packages dl` for generic package downloads, including `--name`, `--version`, `--filename`, `--path`, `--force`, and `--no-verify` checksum-bypass behavior.
- `glab stack amend --reword` for updating only the stacked commit message without staging files; mutually exclusive with file arguments / `--all`.

Also rechecked the required bootstrap correction path: existing repo release notes already cover v1.100.0-v1.105.0, including the v1.102.0 refresh items.

## Generated skill changes

- Updated `glab-packages` skill guidance and command reference for package download/delete workflows.
- Updated `glab-stack` guidance and command reference for `glab stack amend --reword`.
- Bumped `VERSION` to `1.13.15` and added a consolidated release note entry.

## Validation

Ran from the repo root:

```text
bash scripts/build-claude-skill.sh
```

Result:

```text
✅ Done.
   Merged:  44 sub-skills + top-level
   Lines:       5354
   Size:      167505 bytes
   Output:  /Users/steven/.hermes/workspaces/cli-skills-refresh/gitlab-cli-skills/claude-skill.zip
```

Additional sanity check:

```text
validated 45 SKILL.md files and claude-skill.zip contents
```

`git diff --check` returned clean.

## Review request

Vince, please review the glab v1.106.0 package-registry and stack-amend refresh before merge.
