### PR TITLE
feat: refresh glab skills for v1.107.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A collection of skills for AI coding agents following the Agent Skills format. T
 - [`glab-repo`](./glab-repo)
 - [`glab-schedule`](./glab-schedule)
 - [`glab-securefile`](./glab-securefile)
+- [`glab-security`](./glab-security)
 - [`glab-skills`](./glab-skills)
 - [`glab-snippet`](./glab-snippet)
 - [`glab-ssh-key`](./glab-ssh-key)

--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,10 @@
-1.13.15
+1.13.16
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.16
+  - glab v1.107.0 refresh: added `glab-security` coverage for experimental `glab security config enable|disable|status <profile>` project security scan profile management, including Maintainer/Owner and explicit `-R/--repo` safety guidance. Reviewed Duo CLI v9 auto-update release note; existing `glab-duo` forward guidance remains current and no content change was needed there.
 - v1.13.15
   - glab v1.106.0 refresh: updated `glab-packages` for the new `glab packages download` / `dl` and `glab packages delete` / `rm` commands, including checksum verification/overwrite behavior and deletion-by-ID safety guidance. Updated `glab-stack` for `glab stack amend --reword` message-only amendments.
 - v1.13.14

--- a/gitlab-cli-skills/SKILL.md
+++ b/gitlab-cli-skills/SKILL.md
@@ -140,6 +140,7 @@ standalone skill in a sibling directory; open its `SKILL.md` for full details.
 - [`glab-deploy-key`](../glab-deploy-key/SKILL.md) - Deploy keys for automation
 - [`glab-orbit`](../glab-orbit/SKILL.md) - GitLab Knowledge Graph / Orbit discovery, schema inspection, and remote query workflows (EXPERIMENTAL)
 - [`glab-quick-actions`](../glab-quick-actions/SKILL.md) - GitLab slash command quick actions for batching state changes
+- [`glab-security`](../glab-security/SKILL.md) - Project security scan profile enable/disable/status management (EXPERIMENTAL)
 - [`glab-stack`](../glab-stack/SKILL.md) - Stacked/dependent merge requests
 - [`glab-opentofu`](../glab-opentofu/SKILL.md) - Terraform/OpenTofu state management
 

--- a/glab-security/SKILL.md
+++ b/glab-security/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: glab-security
+description: Configure GitLab project security scan profiles with glab. Use when enabling, disabling, or checking GitLab security scan profiles such as SAST, dependency scanning, secret detection, container scanning, or dependency-scanning auto-remediation. Triggers on GitLab security config, security scan profile, enable SAST, dependency scanning, secret detection, glab security.
+---
+
+# glab security
+
+Configure GitLab security features for a project.
+
+> Experimental upstream command surface: verify live `glab security --help` before relying on it in production automation.
+
+## Common commands
+
+```bash
+# Show security command help
+glab security --help
+
+# Enable a scan profile on the current project
+glab security config enable dependency_scanning
+
+# Enable SAST on a specific project
+glab security config enable sast -R gitlab-org/cli
+
+# Check profile status
+glab security config status dependency_scanning
+
+# Disable a scan profile
+glab security config disable dependency_scanning
+
+# Disable dependency scanning auto-remediation
+glab security config disable dependency_scanning_post_processing
+```
+
+## Supported profile examples
+
+Upstream help currently shows these profile names in examples:
+
+- `dependency_scanning`
+- `sast`
+- `dependency_scanning_post_processing` for vulnerable dependency auto-remediation
+
+GitLab may support additional profile names depending on instance version and project features. If a profile fails, use the error output and GitLab project security settings to confirm availability.
+
+## Operational guidance
+
+- You must be a Maintainer or Owner of the target project.
+- Use `-R/--repo` for explicit targeting in agents and scripts; otherwise `glab` resolves the project from the current git remote.
+- Treat `enable` and `disable` as project-configuration writes. Confirm the target project and requested profile before changing state.
+- Prefer `status` before and after a change so the user can see the current scan/profile state.
+
+## Safe workflow
+
+```bash
+PROFILE=sast
+PROJECT=group/project
+
+# 1. Inspect current state
+glab security config status "$PROFILE" -R "$PROJECT"
+
+# 2. Confirm requested change with the user, then apply
+glab security config enable "$PROFILE" -R "$PROJECT"
+
+# 3. Verify
+glab security config status "$PROFILE" -R "$PROJECT"
+```
+
+## Subcommands
+
+See [references/commands.md](references/commands.md) for current `--help` output captured from glab v1.107.0.

--- a/glab-security/references/commands.md
+++ b/glab-security/references/commands.md
@@ -1,0 +1,116 @@
+## glab security
+
+```text
+Configure GitLab security features for a project.
+
+This feature is an experiment and is not ready for production use.
+It might be unstable or removed at any time.
+For more information, see
+https://docs.gitlab.com/policy/development_stages_support/.
+
+USAGE
+  glab security <command> [command] [--flags]
+
+COMMANDS
+  config <command> [command] [--flags]  Configure security scan profiles for a project.
+
+FLAGS
+  -h --help  Show help for this command.
+  -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+```
+
+## glab security config
+
+```text
+Enable, disable, or inspect security scan profiles for a project.
+
+A profile bundles a set of security scans, such as SAST, secret
+detection, dependency scanning, or container scanning, or post-scan
+processing on given scans, like dependency scanning auto remediation.
+
+USAGE
+  glab security config <command> [command] [--flags]
+
+COMMANDS
+  disable <profile> [--flags]  Disable a security scan profile for a project.
+  enable <profile> [--flags]   Enable a security scan profile for a project.
+  status <profile> [--flags]   Show the status of a security scan profile for a project.
+
+FLAGS
+  -h --help  Show help for this command.
+  -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+```
+
+## glab security config enable
+
+```text
+Attach a security scan profile to a project.
+
+You must be a Maintainer or Owner of the project.
+
+USAGE
+  glab security config enable <profile> [--flags]
+
+EXAMPLES
+  # Enable dependency scanning on the current project
+  $ glab security config enable dependency_scanning
+
+  # Enable SAST on a specific project
+  $ glab security config enable sast -R gitlab-org/cli
+
+  # Enable auto-remediation for vulnerable dependencies
+  $ glab security config enable dependency_scanning_post_processing
+
+FLAGS
+  -h --help  Show help for this command.
+  -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+```
+
+## glab security config disable
+
+```text
+Detach a security scan profile from a project.
+
+You must be a Maintainer or Owner of the project.
+
+USAGE
+  glab security config disable <profile> [--flags]
+
+EXAMPLES
+  # Disable dependency scanning on the current project
+  $ glab security config disable dependency_scanning
+
+  # Disable SAST on a specific project
+  $ glab security config disable sast -R gitlab-org/cli
+
+  # Disable auto-remediation for vulnerable dependencies
+  $ glab security config disable dependency_scanning_post_processing
+
+FLAGS
+  -h --help  Show help for this command.
+  -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+```
+
+## glab security config status
+
+```text
+Show whether a security scan profile is attached to a project and its
+current scan status.
+
+USAGE
+  glab security config status <profile> [--flags]
+
+EXAMPLES
+  # Show dependency scanning status for the current project
+  $ glab security config status dependency_scanning
+
+  # Show SAST status for a specific project
+  $ glab security config status sast -R gitlab-org/cli
+
+  # Show auto-remediation status for vulnerable dependencies
+  $ glab security config status dependency_scanning_post_processing
+
+FLAGS
+  -h --help  Show help for this command.
+  -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+```


### PR DESCRIPTION
## Upstream source

- CLI: GitLab CLI (`glab`) v1.107.0
- Source: GitLab canonical release API / release page: https://gitlab.com/gitlab-org/cli/-/releases/v1.107.0

## Upstream CLI changes reviewed

- New experimental `glab security config` surface for managing project security scan profiles:
  - `glab security config enable <profile>`
  - `glab security config disable <profile>`
  - `glab security config status <profile>`
- Duo CLI v9 auto-update support noted in upstream release; existing `glab-duo` guidance remains current.
- Documentation-only/dependency/maintenance release notes did not require skill content changes.

## Generated skill changes

- Added `glab-security` standalone skill with safety guidance for project security profile writes.
- Captured v1.107.0 help output in `glab-security/references/commands.md`.
- Linked `glab-security` from the README and top-level `gitlab-cli-skills` orchestrator.
- Updated `VERSION` to 1.13.16 with release metadata.

## Validation

- Downloaded and inspected `glab` v1.107.0 (`glab 1.107.0 (85b59ceb)`).
- Ran `bash scripts/build-claude-skill.sh` successfully; output included `45 sub-skills + top-level`, `Lines: 5425`, `Size: 169685 bytes`.
- Ran `unzip -t claude-skill.zip`; result: `No errors detected in compressed data of claude-skill.zip`.

Vince: please review before merge/release.