### PR TITLE
docs: refresh glab skills for v1.108.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,14 @@
-1.13.16
+1.13.17
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.17
+  - glab v1.108.0 refresh: documented `glab ci status --wait` for non-interactive pipeline completion waits, including the JSON-output incompatibility shared by the polling/compact text modes.
+  - Updated `glab-securefile` for deletion by exact file name via `--name`, with explicit confirmation and non-interactive `--yes` safety guidance.
+  - Updated `glab-mr` for note/discussion IDs and absolute-plus-relative timestamps in `glab mr note list`, including filters and JSON output for stable automation identifiers.
+  - Updated `glab-duo` for the GA Duo CLI path, current prerequisites, auto-run/download settings, and `--update`; refreshed `glab-config` with the complete documented global setting set.
+  - Documented that interactive re-authentication preserves saved API host, SSH host, and container-registry domains unless explicitly overridden. Reviewed issue/MR rendering fixes and experimental security synopsis changes; no additional operational skill changes were needed for those fixes.
 - v1.13.16
   - glab v1.107.0 refresh: added `glab-security` coverage for experimental `glab security config enable|disable|status <profile>` project security scan profile management, including Maintainer/Owner and explicit `-R/--repo` safety guidance. Reviewed Duo CLI v9 auto-update release note; existing `glab-duo` forward guidance remains current and no content change was needed there.
 - v1.13.15

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -60,6 +60,14 @@ glab auth login \
   --container-registry-domains "registry.gitlab.com,gitlab.com"
 ```
 
+When re-authenticating interactively, `glab` preserves saved per-host values such as a custom API host, SSH host, and container-registry domains unless you explicitly override them with flags or prompts. Verify these values after re-authentication instead of deleting the config preemptively:
+
+```bash
+glab config get api_host --host gitlab.company.com
+glab config get ssh_host --host gitlab.company.com
+glab config get container_registry_domains --host gitlab.company.com
+```
+
 **CI auto-login:** when enabled, token environment variables such as `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, or `OAUTH_TOKEN` still take precedence over stored credentials and `CI_JOB_TOKEN`.
 
 ### Agentic and multi-account setups

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -30,6 +30,9 @@ glab ci status --output=json --jq '.pipeline.status'
 # View current pipeline status
 glab ci status
 
+# Wait non-interactively until the current pipeline finishes
+glab ci status --wait
+
 # View detailed pipeline info
 glab ci view
 
@@ -184,7 +187,8 @@ glab ci delete <pipeline-id>
 
 **Watching live pipeline status:**
 - `glab ci status --live` keeps polling while the pipeline is in transient in-progress states such as `created`, `waiting_for_resource`, `preparing`, `pending`, `running`, and `scheduled`.
-- `--live` is for terminal watching; it is not compatible with `--output json` / `--jq`. For automation, run `glab ci status --output=json --jq ...` repeatedly or poll the API.
+- `glab ci status --wait` also polls until the pipeline reaches a terminal state, but suppresses the post-run interactive action prompt. It exits non-zero when the final pipeline fails and follows a newer pipeline if the observed one is auto-canceled and replaced for the same branch.
+- `--live` and `--wait` are text-mode polling options, and `--compact` is also text-only. None of these modes is compatible with `--output json` / `--jq`. For structured automation, run `glab ci status --output=json --jq ...` repeatedly or poll the API.
 
 **Pipeline stuck/pending:**
 - Check runner availability: View pipeline in web UI

--- a/glab-ci/references/commands.md
+++ b/glab-ci/references/commands.md
@@ -380,33 +380,41 @@ Command "artifact" is deprecated, use 'glab job artifact' instead.
 ## ci status
 
 ```
+View CI/CD pipeline status.
 
-  View a running CI/CD pipeline on current or other branch specified.                                                   
-         
-  USAGE  
-         
-    glab ci status [--flags]                   
-            
-  EXAMPLES  
-            
-    $ glab ci status --live                    
-                                               
-    # A more compact view                      
-    $ glab ci status --compact                 
-                                               
-    # Get the pipeline for the main branch     
-    $ glab ci status --branch=main             
-                                               
-    # Get the pipeline for the current branch  
-    $ glab ci status                           
-         
-  FLAGS  
-         
-    -b --branch   Check pipeline status for a branch. (default current branch)
-    -c --compact  Show status in compact format.
-    -h --help     Show help for this command.
-    -l --live     Show status in real time until the pipeline ends.
-    -R --repo     Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+Defaults to the current branch.
+Use --live for real-time updates. Use --compact for a condensed view.
+
+USAGE
+  glab ci status [flags]
+
+EXAMPLES
+  # View the pipeline status in real time
+  glab ci status --live
+
+  # Wait until the pipeline is finished, without an interactive action prompt
+  glab ci status --wait
+
+  # A more compact view
+  glab ci status --compact
+
+  # Get the pipeline for the main branch
+  glab ci status --branch=main
+
+  # Get the pipeline for the current branch
+  glab ci status
+
+FLAGS
+  -b, --branch string  Check pipeline status for a branch. Defaults to the current branch.
+  -c, --compact        Show status in compact format.
+      --jq string      Filter JSON output with a jq expression.
+  -l, --live           Show status in real time until the pipeline ends.
+  -F, --output string  Format output as: text, json. JSON is not compatible with --live, --wait, or --compact. (default "text")
+  -w, --wait           Wait to return until the pipeline is finished, and provide output without a prompt.
+
+INHERITED FLAGS
+  -h, --help           Show help for this command.
+  -R, --repo string    Select another repository. OWNER/REPO, GROUP/NAMESPACE/REPO, full URL, and Git URL are accepted.
 ```
 
 ## ci trace

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -11,19 +11,24 @@ description: Manage glab CLI configuration settings including defaults, preferen
 
   Manage key/value strings.
   Current respected settings:
+  - branch_prefix: Prefix used by glab stack for generated branch names.
   - browser: If unset, uses the default browser. Override with environment variable $BROWSER.
-  - check_update: If true, notifies of new versions of glab. Defaults to true. Override with environment variable
-  $GLAB_CHECK_UPDATE.
-  - display_hyperlinks: If true, and using a TTY, outputs hyperlinks for issues and merge request lists. Defaults to
-  false.
+  - check_update: Notify about new glab versions. Override with $GLAB_CHECK_UPDATE.
+  - display_hyperlinks: Enable terminal hyperlinks. Override with $FORCE_HYPERLINKS.
+  - duo_cli_auto_download / duo_cli_auto_run: Skip Duo CLI download/run prompts.
   - editor: If unset, uses the default editor. Override with environment variable $EDITOR.
-  - glab_pager: Your desired pager command to use, such as 'less -R'.
-  - glamour_style: Your desired Markdown renderer style. Options are dark, light, notty. Custom styles are available
-  using [glamour](https://github.com/charmbracelet/glamour#styles).
+  - git_protocol: Git protocol, ssh or https.
+  - glab_pager: Pager command, such as less -R.
+  - glamour_style: Markdown renderer style: dark, light, notty, or a custom glamour style.
   - host: If unset, defaults to `https://gitlab.com`.
+  - no_prompt: Disable interactive prompts. Prefer the $GLAB_NO_PROMPT override in automation.
+  - notify_skill_updates: Show installed agent-skill update notices. Override with $GLAB_NOTIFY_SKILL_UPDATES.
+  - orbit_local_auto_download / orbit_local_auto_run: Skip Orbit local CLI download/run prompts.
+  - remote_alias: Preferred Git remote name when multiple remotes exist.
+  - show_whats_new: Show the one-time post-upgrade glab whatsnew banner. Override with $GLAB_SHOW_WHATS_NEW.
+  - telemetry: Enable usage data to the GitLab instance. Override with $GLAB_SEND_TELEMETRY.
   - token: Your GitLab access token. Defaults to environment variables.
-  - visual: Takes precedence over 'editor'. If unset, uses the default editor. Override with environment variable
-  $VISUAL.
+  - visual: Takes precedence over editor. Override with $VISUAL.
   USAGE
     glab config [command] [--flags]
   COMMANDS
@@ -106,6 +111,13 @@ glab config set glab_pager "less -R" --global
 
 # Disable update checks
 glab config set check_update false --global
+
+# Select the Git remote glab should prefer
+glab config set remote_alias origin --global
+
+# Allow Duo CLI to download and run without wrapper prompts
+glab config set duo_cli_auto_download true --global
+glab config set duo_cli_auto_run true --global
 
 # Set default host
 glab config set host https://gitlab.mycompany.com --global

--- a/glab-config/references/commands.md
+++ b/glab-config/references/commands.md
@@ -8,19 +8,26 @@
                                                                                                                         
   Current respected settings:                                                                                           
                                                                                                                         
-  - browser: If unset, uses the default browser. Override with environment variable $BROWSER.                           
-  - check_update: If true, notifies of new versions of glab. Defaults to true. Override with environment variable       
-  $GLAB_CHECK_UPDATE.                                                                                                   
-  - display_hyperlinks: If true, and using a TTY, outputs hyperlinks for issues and merge request lists. Defaults to    
-  false.                                                                                                                
-  - editor: If unset, uses the default editor. Override with environment variable $EDITOR.                              
-  - glab_pager: Your desired pager command to use, such as 'less -R'.                                                   
-  - glamour_style: Your desired Markdown renderer style. Options are dark, light, notty. Custom styles are available    
-  using [glamour](https://github.com/charmbracelet/glamour#styles).                                                     
-  - host: If unset, defaults to `https://gitlab.com`.                                                                   
-  - token: Your GitLab access token. Defaults to environment variables.                                                 
-  - visual: Takes precedence over 'editor'. If unset, uses the default editor. Override with environment variable       
-  $VISUAL.                                                                                                              
+  - branch_prefix: Prefix used by glab stack when naming generated branches. Defaults to $USER, then glab-stack.
+  - browser: If unset, uses the default browser. Override with $BROWSER.
+  - check_update: Notify about new glab versions. Defaults to true. Override with $GLAB_CHECK_UPDATE.
+  - display_hyperlinks: Enable terminal hyperlinks. Defaults to true. Override with $FORCE_HYPERLINKS.
+  - duo_cli_auto_download: Automatically download Duo CLI without prompting.
+  - duo_cli_auto_run: Automatically run Duo CLI without prompting.
+  - editor: If unset, uses the default editor. Override with $EDITOR.
+  - git_protocol: Git protocol. Supported values: ssh, https. Defaults to ssh.
+  - glab_pager: Pager command, such as less -R.
+  - glamour_style: Markdown renderer style: dark, light, notty, or a custom glamour style.
+  - host: If unset, defaults to https://gitlab.com.
+  - no_prompt: Disable interactive prompts. Defaults to false.
+  - notify_skill_updates: Show installed agent-skill update notices. Defaults to true. Override with $GLAB_NOTIFY_SKILL_UPDATES.
+  - orbit_local_auto_download: Automatically download Orbit local CLI without prompting.
+  - orbit_local_auto_run: Automatically run Orbit local CLI without prompting.
+  - remote_alias: Preferred Git remote name when multiple remotes exist.
+  - show_whats_new: Show the one-time post-upgrade glab whatsnew banner. Defaults to true. Override with $GLAB_SHOW_WHATS_NEW.
+  - telemetry: Send usage data to the GitLab instance. Defaults to true. Override with $GLAB_SEND_TELEMETRY.
+  - token: GitLab access token. Defaults to environment variables.
+  - visual: Takes precedence over editor. Override with $VISUAL.
                                                                                                                         
          
   USAGE  

--- a/glab-container-registry/SKILL.md
+++ b/glab-container-registry/SKILL.md
@@ -7,7 +7,7 @@ description: Manage GitLab container registry repositories and tags with glab. U
 
 Manage GitLab container registry repositories and tags from the CLI.
 
-> Added in glab v1.103.0. Repository IDs come from registry repository list/view output, not from Git repository project IDs.
+Repository IDs come from registry repository list/view output, not from Git repository project IDs.
 
 ## Common workflows
 

--- a/glab-duo/SKILL.md
+++ b/glab-duo/SKILL.md
@@ -28,7 +28,7 @@ description: Interact with GitLab Duo AI assistant for code suggestions and chat
   COMMANDS
 
     ask <prompt> [--flags]  Generate Git commands from natural language.
-    cli [command]           Run the GitLab Duo CLI (EXPERIMENTAL)
+    cli [command]           Run the GitLab Duo CLI
 
   FLAGS
 
@@ -51,11 +51,13 @@ Treat `glab duo ask` as legacy guidance only for older installed versions that s
 glab duo cli
 ```
 
-Use `glab duo cli` when you specifically want the experimental GitLab Duo CLI surface that `glab` now exposes.
+Use `glab duo cli` for the forward-looking GitLab Duo Agent Platform experience. `glab` handles authentication for the Duo CLI after you authenticate once with `glab auth login`.
+
+Prerequisites for the GA path are GitLab 19.2 or later and the GitLab Duo Agent Platform prerequisites. GitLab Self-Managed and Dedicated instances must also allow Duo CLI access. GitLab 18.11 through 19.1 require beta and experimental features to be enabled.
 
 ### Installing GitLab Duo CLI
 
-`glab duo cli` supports `--install` and `--yes` flags:
+`glab duo cli` supports install, update, and non-interactive confirmation flags:
 
 ```bash
 # Install GitLab Duo CLI interactively
@@ -63,13 +65,18 @@ glab duo cli --install
 
 # Install GitLab Duo CLI non-interactively (auto-confirm)
 glab duo cli --install --yes
+
+# Check for and install a Duo CLI update
+glab duo cli --update
 ```
 
 Use `--install` to download and install the GitLab Duo CLI binaries. Use `--yes` to skip confirmation prompts during installation, which is useful for automation and CI/CD pipelines.
 
+To persist prompt behavior, set `duo_cli_auto_download` and `duo_cli_auto_run` with `glab config set ... --global`. All unrecognized arguments and flags after `glab duo cli` pass through to the Duo CLI binary.
+
 ### Important documentation note
 
-Guidance that recommends `glab duo update` is stale; rely on live help before using any Duo subcommand that is not documented here.
+Guidance that recommends `glab duo update` is stale; the current wrapper form is `glab duo cli --update`. Rely on live help before using any Duo subcommand that is not documented here.
 
 When local CLI help and external documentation diverge during a transition, document the current upstream direction clearly and note compatibility caveats only when they materially affect usage.
 

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -78,8 +78,10 @@ glab mr create --draft --title "WIP: Feature X"
    glab mr note create 123 --file src/cache.ts --line 42 -m "Please extract this branch"
    glab mr note create 123 --file src/cache.ts --old-line 17 -m "Why was this removed?"
 
-   # List discussion threads on the MR (experimental)
+   # List discussion threads and expose note/discussion IDs (experimental)
    glab mr note list 123
+   glab mr note list 123 --state unresolved --type diff
+   glab mr note list 123 --output json
 
    # Resolve or reopen a discussion by note/discussion ID (experimental)
    glab mr note resolve 3107030349 123
@@ -156,6 +158,26 @@ glab mr merge 123
 
 **Automation:**
 - Script: `scripts/mr-review-workflow.sh` for automated review + test workflow
+
+## Listing and targeting MR discussions
+
+`glab mr note list` text output includes each note ID and discussion ID, plus both relative and absolute timestamps. Use those identifiers with `resolve`, `reopen`, or `--reply` rather than scraping author/body text.
+
+```bash
+# Filter the text view
+glab mr note list 123 --type diff --state unresolved
+glab mr note list 123 --file src/app.ts
+
+# Prefer JSON when an automation needs stable IDs
+glab mr note list 123 --output json \
+  --jq '.[] | {discussion_id: .id, note_ids: [.notes[].id]}'
+
+# Act on the verified identifier
+glab mr note resolve <discussion-or-note-id> 123
+glab mr note reopen <discussion-or-note-id> 123
+```
+
+`--type` accepts `all`, `general`, `diff`, or `system`; `--state` accepts `all`, `resolved`, or `unresolved`; `--file` limits results to diff notes on one path. These subcommands remain experimental, so confirm live help when scripting across mixed `glab` versions.
 
 ## Native MR note flow (`glab mr note create`)
 

--- a/glab-mr/references/commands.md
+++ b/glab-mr/references/commands.md
@@ -466,6 +466,49 @@ Command "for" is deprecated, use `glab mr create --related-issue <issueID>`
     --unique                                    Don't create a comment or note if it already exists.
 ```
 
+## mr note list
+
+```
+Fetches and displays merge request discussions.
+Uses the same output format as glab mr view --comments.
+Supports filtering by note type, resolution state, and file path.
+Supports JSON output for scripting. Text output includes note and discussion IDs
+and shows absolute time alongside relative time.
+
+USAGE
+  glab mr note list [<id> | <branch>] [flags]
+
+EXAMPLES
+  # List all discussions on the current branch's MR
+  glab mr note list
+
+  # List diff comments only
+  glab mr note list --type diff
+
+  # List unresolved discussions
+  glab mr note list --state unresolved
+
+  # List discussions on a specific file
+  glab mr note list --file src/main.go
+
+  # JSON output for scripting
+  glab mr note list -F json --jq '.[].notes[].body'
+
+  # List discussions on MR 123
+  glab mr note list 123
+
+FLAGS
+      --file string    Show only diff notes on this file path.
+  -F, --output string  Format output as: text, json. (default "text")
+      --jq string      Filter JSON output with a jq expression.
+      --state string   Resolution state: all, resolved, unresolved. (default "all")
+  -t, --type string    Note type: all, general, diff, system. (default "all")
+
+INHERITED FLAGS
+  -h, --help           Show help for this command.
+  -R, --repo string    Select another repository. OWNER/REPO, GROUP/NAMESPACE/REPO, full URL, and Git URL are accepted.
+```
+
 ## mr rebase
 
 ```

--- a/glab-packages/SKILL.md
+++ b/glab-packages/SKILL.md
@@ -7,7 +7,7 @@ description: List, upload, download, and delete GitLab project package registry 
 
 List packages in a GitLab project's package registry, upload/download generic package files, and delete package registry entries by ID.
 
-> Added in glab v1.103.0. `glab packages list` / `ls` lists project package registries. glab v1.104.0 added `glab packages upload` / `ul` for generic package uploads. glab v1.106.0 added `glab packages download` / `dl` for generic package downloads and `glab packages delete` / `rm` for package deletion by numeric ID.
+`glab packages list` / `ls` lists project package registries. The current command surface also includes `upload` / `ul` for generic package uploads, `download` / `dl` for generic package downloads, and `delete` / `rm` for package deletion by numeric ID.
 
 ## Quick start
 

--- a/glab-securefile/SKILL.md
+++ b/glab-securefile/SKILL.md
@@ -25,7 +25,8 @@ description: Manage secure files for CI/CD including upload, download, list, and
     download <fileID> [--flags]        Download a secure file for a project.
     get <fileID>                       Get details of a project secure file. (GitLab 18.0 and later)
     list [--flags]                     List secure files for a project.
-    remove <fileID> [--flags]          Remove a secure file.
+    remove [<fileID> | --id <id> | --name <name>] [--flags]
+                                       Remove a secure file.
          
   FLAGS  
          
@@ -38,6 +39,22 @@ description: Manage secure files for CI/CD including upload, download, list, and
 ```bash
 glab securefile --help
 ```
+
+## Removing secure files
+
+Secure-file deletion accepts a positional numeric ID, `--id`, or an exact file name via `--name`:
+
+```bash
+# Interactive confirmation
+glab securefile remove 1
+glab securefile remove --id 1
+glab securefile remove --name signing-certificate.p12
+
+# Approved non-interactive deletion
+glab securefile remove --name signing-certificate.p12 --yes
+```
+
+Deletion is permanent. In non-interactive environments, `--yes` / `-y` is required. Resolve and verify the intended project with `-R/--repo` before deleting, and prefer an ID when duplicate or ambiguous naming is possible.
 
 ## Subcommands
 

--- a/glab-securefile/references/commands.md
+++ b/glab-securefile/references/commands.md
@@ -20,7 +20,8 @@
     download <fileID> [--flags]        Download a secure file for a project.
     get <fileID>                       Get details of a project secure file. (GitLab 18.0 and later)
     list [--flags]                     List secure files for a project.
-    remove <fileID> [--flags]          Remove a secure file.
+    remove [<fileID> | --id <id> | --name <name>] [--flags]
+                                       Remove a secure file.
          
   FLAGS  
          
@@ -161,31 +162,38 @@
 ## securefile remove
 
 ```
+Remove a secure file from a project.
 
-  Remove a secure file.                                                                                                 
-         
-  USAGE  
-         
-    glab securefile remove <fileID> [--flags]            
-            
-  EXAMPLES  
-            
-    Remove a project's secure file using the file's ID.  
-    - glab securefile remove 1                           
-                                                         
-    Skip the confirmation prompt and force delete.       
-    - glab securefile remove 1 -y                        
-                                                         
-    Remove a project's secure file with 'rm' alias.      
-    - glab securefile rm 1                               
-                                                         
-    Remove a project's secure file with 'delete' alias.  
-    - glab securefile delete 1                           
-         
-  FLAGS  
-         
-    -h --help  Show help for this command.
-    -R --repo  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
-    -y --yes   Skip the confirmation prompt.
+USAGE
+  glab securefile remove [<fileID> | --id <id> | --name <name>] [flags]
+
+ALIASES
+  rm
+  delete
+
+EXAMPLES
+  # Remove a secure file by ID
+  glab securefile remove 1
+  glab securefile remove --id 1
+
+  # Remove a secure file by name
+  glab securefile remove --name example.txt
+
+  # Skip the confirmation prompt
+  glab securefile remove 1 -y
+  glab securefile remove --name example.txt -y
+
+  # Aliases
+  glab securefile rm 1
+  glab securefile delete --name example.txt
+
+FLAGS
+      --id int       ID of the secure file to remove.
+      --name string  Name of the secure file to remove.
+  -y, --yes          Skip the confirmation prompt.
+
+INHERITED FLAGS
+  -h, --help         Show help for this command.
+  -R, --repo string  Select another repository. OWNER/REPO, GROUP/NAMESPACE/REPO, full URL, and Git URL are accepted.
 ```
 

--- a/glab-security/SKILL.md
+++ b/glab-security/SKILL.md
@@ -66,4 +66,4 @@ glab security config status "$PROFILE" -R "$PROJECT"
 
 ## Subcommands
 
-See [references/commands.md](references/commands.md) for current `--help` output captured from glab v1.107.0.
+See [references/commands.md](references/commands.md) for the current captured `--help` output.


### PR DESCRIPTION
## Upstream source

- GitLab CLI `glab` **v1.108.0**
- Canonical release: https://gitlab.com/gitlab-org/cli/-/releases/v1.108.0
- Compared against: `v1.107.0...v1.108.0`

## Upstream CLI changes reviewed

- Added `glab ci status --wait` for non-interactive pipeline completion waits.
- Added secure-file removal by exact name with `glab securefile remove --name`.
- `glab mr note list` now shows note/discussion IDs and absolute plus relative timestamps.
- Updated GitLab Duo CLI documentation for the GA path and current wrapper options.
- Expanded `glab config` help with the current respected setting set.
- Interactive re-authentication preserves saved API/SSH/registry values.
- Reviewed issue/MR rendering fixes and experimental security synopsis changes.

## Skill/package changes

- Updated `glab-ci`, `glab-securefile`, `glab-mr`, `glab-duo`, `glab-config`, and `glab-auth` operational guidance and command references.
- Removed stale CLI-version prose from affected current-operation skills; release history remains in `VERSION`.
- Bumped the skill package version to `1.13.17`.
- No repo-local scheduler, refresh script, or GitHub Actions workflow was added.

## Validation

- `git diff --check` — passed.
- Shell syntax for every tracked `*.sh` — passed.
- Python syntax for every tracked `*.py` — passed.
- 46 `SKILL.md` files — frontmatter present, names unique, Markdown fences balanced, no root `SKILL.md`, and no CLI-version prose — passed.
- `bash scripts/build-claude-skill.sh` — merged 45 sub-skills plus top-level, 5,495 lines / 173,636 bytes.
- `claude-skill.zip` — integrity passed; exactly `gitlab-cli-skills/` and `gitlab-cli-skills/SKILL.md`.
- `npx skills add . --list` — local path validated; 46 skills discovered.

## Review request

Vince, please review the command semantics and safety guidance before merge. This PR is intentionally unmerged.
