### PR TITLE
docs: refresh glab skills for v1.109.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,13 @@
-1.13.17
+1.13.18
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.18
+  - glab v1.109.0 refresh: added `glab variable import` coverage for restoring project/group variables from export-shaped JSON, including existing-variable and hidden-value caveats.
+  - Added `glab securefile update` / `overwrite` coverage, including confirmation, unchanged-content behavior, and the post-update ID change.
+  - Documented XDG-aware config search precedence and release creation from GitLab CI with `CI_JOB_TOKEN` auto-login versus project/group access tokens.
+  - Reviewed the unauthenticated `glab api` header fix, dependency-firewall foundations, and generated-doc pruning; no additional operational skill changes were needed.
 - v1.13.17
   - glab v1.108.0 refresh: documented `glab ci status --wait` for non-interactive pipeline completion waits, including the JSON-output incompatibility shared by the polling/compact text modes.
   - Updated `glab-securefile` for deletion by exact file name via `--name`, with explicit confirmation and non-interactive `--yes` safety guidance.

--- a/gitlab-cli-skills/SKILL.md
+++ b/gitlab-cli-skills/SKILL.md
@@ -8,7 +8,7 @@ requirements:
   binaries_optional:
     - cosign
   notes: |
-    Requires GitLab authentication via 'glab auth login' (stores token in ~/.config/glab-cli/config.yml).
+    Requires GitLab authentication via 'glab auth login' (stores token in the active global glab config file).
     Some features may access sensitive files: SSH keys (~/.ssh/id_rsa for DPoP), Docker config (~/.docker/config.json for registry auth).
     Review auth workflows and script contents before autonomous use.
 openclaw:
@@ -19,7 +19,7 @@ openclaw:
           GitLab personal access token with 'api' scope. Used by automation
           scripts (e.g. post-inline-comment.py) to post MR comments via the
           REST API. If not set, scripts fall back to reading the token from
-          glab CLI config (~/.config/glab-cli/config.yml).
+          the active global glab CLI config.
         required: false
         fallback: glab config (set via glab auth login)
     network:
@@ -66,7 +66,7 @@ source ~/.config/openclaw/env/gitlab-<actor>.env
 set +a
 ```
 
-Plain `source` updates the current shell but may not export variables to child processes such as `glab`. If the token/host vars are not exported, `glab` may silently fall back to shared stored auth from `~/.config/glab-cli/config.yml`, which can make the wrong account appear to perform the action.
+Plain `source` updates the current shell but may not export variables to child processes such as `glab`. If the token/host vars are not exported, `glab` may silently fall back to shared stored auth from the active global glab config file, which can make the wrong account appear to perform the action.
 
 ### Required pre-flight before any GitLab write
 

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -68,7 +68,7 @@ glab config get ssh_host --host gitlab.company.com
 glab config get container_registry_domains --host gitlab.company.com
 ```
 
-**CI auto-login:** when enabled, token environment variables such as `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, or `OAUTH_TOKEN` still take precedence over stored credentials and `CI_JOB_TOKEN`.
+**CI auto-login:** `GLAB_ENABLE_CI_AUTOLOGIN=true` lets glab use `CI_JOB_TOKEN` in GitLab CI/CD without a stored login. `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, and `OAUTH_TOKEN` still take precedence, so leave them unset when the intended credential is `CI_JOB_TOKEN`. Use explicit env tokens instead when a command needs a project, group, or personal access token.
 
 ### Agentic and multi-account setups
 
@@ -98,7 +98,7 @@ set +a
 Why this matters:
 - plain `source` does not necessarily export variables to child processes
 - `glab` only sees env vars that are exported
-- if `glab` cannot see the env token, it may silently fall back to shared stored auth in `~/.config/glab-cli/config.yml`
+- if `glab` cannot see the env token, it may silently fall back to shared stored auth in the active global config file
 - if another env file was sourced earlier in the same shell/session, identity can be sticky in ways that are unsafe for writes unless you deliberately switch and verify
 
 That fallback/shared-auth behavior is convenient for humans, but in multi-agent automation it can cause the wrong GitLab account to post comments, create MRs, or approve work.

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -63,6 +63,17 @@ glab config get https_proxy --host gitlab.mycompany.com
 
 **Precedence:** Per-host config overrides global config. Global config overrides the `HTTPS_PROXY` / `https_proxy` environment variables.
 
+## Configuration file search order
+
+glab uses the first global config found in this order:
+
+1. `$GLAB_CONFIG_DIR/config.yml` when `GLAB_CONFIG_DIR` is set.
+2. `~/.config/glab-cli/config.yml`, retained as the cross-platform legacy location.
+3. `$XDG_CONFIG_HOME/glab-cli/config.yml` (for example, `~/Library/Application Support/glab-cli/config.yml` on macOS when the legacy file is absent).
+4. `$XDG_CONFIG_DIRS/glab-cli/config.yml` (default `/etc/xdg/glab-cli/config.yml`) for system-wide defaults.
+
+The first file wins; files are not merged. If both the legacy and platform-specific XDG files exist, glab uses the legacy file and warns. Repository-local settings live in `.git/glab-cli/config.yml`, while per-host settings are stored in the selected global file. Prefer `glab config get`, `set`, and `edit` over directly modifying files, and do not copy stored tokens into logs or version control.
+
 ## Env-first agent pattern
 
 For agentic setups, prefer per-agent env files over one shared shell profile. Example:

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -65,14 +65,15 @@ glab config get https_proxy --host gitlab.mycompany.com
 
 ## Configuration file search order
 
-glab uses the first global config found in this order:
+glab uses this global config selection:
 
-1. `$GLAB_CONFIG_DIR/config.yml` when `GLAB_CONFIG_DIR` is set.
-2. `~/.config/glab-cli/config.yml`, retained as the cross-platform legacy location.
-3. `$XDG_CONFIG_HOME/glab-cli/config.yml` (for example, `~/Library/Application Support/glab-cli/config.yml` on macOS when the legacy file is absent).
-4. `$XDG_CONFIG_DIRS/glab-cli/config.yml` (default `/etc/xdg/glab-cli/config.yml`) for system-wide defaults.
+1. `$GLAB_CONFIG_DIR/config.yml` when `GLAB_CONFIG_DIR` is set. This is an explicit override; glab uses this directory even when no config file exists there yet.
+2. Otherwise, the first existing normal candidate wins:
+   - `~/.config/glab-cli/config.yml`, retained as the legacy location.
+   - `$XDG_CONFIG_HOME/glab-cli/config.yml` (on macOS this defaults to `~/Library/Application Support/glab-cli/config.yml`).
+   - `$XDG_CONFIG_DIRS/glab-cli/config.yml` for system-wide defaults. The usual Linux default is `/etc/xdg/glab-cli/config.yml`; on macOS, set `XDG_CONFIG_DIRS` explicitly when relying on system-wide config.
 
-The first file wins; files are not merged. If both the legacy and platform-specific XDG files exist, glab uses the legacy file and warns. Repository-local settings live in `.git/glab-cli/config.yml`, while per-host settings are stored in the selected global file. Prefer `glab config get`, `set`, and `edit` over directly modifying files, and do not copy stored tokens into logs or version control.
+Files are not merged. If both the legacy and platform-specific XDG files exist, glab uses the legacy file and warns. Repository-local settings live in `.git/glab-cli/config.yml`, while per-host settings are stored in the selected global file. Prefer `glab config get`, `set`, and `edit` over directly modifying files, and do not copy stored tokens into logs or version control.
 
 ## Env-first agent pattern
 
@@ -94,7 +95,7 @@ source ~/.config/openclaw/env/gitlab-<agent>.env
 set +a
 ```
 
-A plain `source ~/.config/openclaw/env/gitlab-<agent>.env` updates the current shell but may leave the values unexported. In that case `glab` can miss the env overrides and silently reuse stored auth from `~/.config/glab-cli/config.yml`.
+A plain `source ~/.config/openclaw/env/gitlab-<agent>.env` updates the current shell but may leave the values unexported. In that case `glab` can miss the env overrides and silently reuse stored auth from the active global config file.
 
 Use distinct GitLab bot/service accounts when agents need distinct visible identities. Multiple PATs on one GitLab user still act as that same user.
 

--- a/glab-release/SKILL.md
+++ b/glab-release/SKILL.md
@@ -52,6 +52,19 @@ glab release create v1.2.0
 glab release update v1.2.0 --name "My Release"
 ```
 
+## Creating releases in GitLab CI/CD
+
+For a pipeline job, prefer the predefined `CI_JOB_TOKEN` with CI auto-login. The Releases API accepts that credential in the `JOB-TOKEN` header:
+
+```bash
+GLAB_ENABLE_CI_AUTOLOGIN=true \
+  glab release create "$CI_COMMIT_TAG" \
+  --notes-file CHANGELOG.md \
+  --ref "$CI_COMMIT_SHA"
+```
+
+Do not assign `CI_JOB_TOKEN` to `GITLAB_TOKEN`: glab sends `GITLAB_TOKEN` as `PRIVATE-TOKEN`, which the Releases API rejects for a job token and can surface as `404 Not Found`. When job-token access is insufficient, use an approved project or group access token with `api` scope through `GITLAB_TOKEN`; never print that token.
+
 ## Subcommands
 
 See [references/commands.md](references/commands.md) for full `--help` output.

--- a/glab-release/SKILL.md
+++ b/glab-release/SKILL.md
@@ -54,7 +54,7 @@ glab release update v1.2.0 --name "My Release"
 
 ## Creating releases in GitLab CI/CD
 
-For a pipeline job, prefer the predefined `CI_JOB_TOKEN` with CI auto-login. The Releases API accepts that credential in the `JOB-TOKEN` header:
+For a pipeline job, prefer the predefined `CI_JOB_TOKEN` with glab CI auto-login; see [glab-auth](../glab-auth/SKILL.md) for the general mechanism and environment-variable precedence. The Releases API accepts that credential in the `JOB-TOKEN` header:
 
 ```bash
 GLAB_ENABLE_CI_AUTOLOGIN=true \

--- a/glab-release/references/commands.md
+++ b/glab-release/references/commands.md
@@ -47,6 +47,12 @@
   4. Optional. To fetch the new tag locally after the release, run                                                      
      `git fetch --tags origin`.                                                                                         
                                                                                                                         
+  Authentication in CI/CD:
+
+  - Recommended: Use `CI_JOB_TOKEN` and set `GLAB_ENABLE_CI_AUTOLOGIN=true`. glab sends the token in the `JOB-TOKEN` header, which the Releases API accepts.
+  - Alternative: Use `GITLAB_TOKEN` set to a project or group access token with the `api` scope.
+  - Do not set `GITLAB_TOKEN=$CI_JOB_TOKEN`; the Releases API returns `404 Not Found` because that variable is sent in the `PRIVATE-TOKEN` header.
+
          
   USAGE  
          
@@ -63,6 +69,12 @@
     # Use release notes from a file                                                                  
     $ glab release create v1.0.1 -F changelog.md                                                     
                                                                                                      
+    # Create a release from a CI/CD job using the job token
+    $ GLAB_ENABLE_CI_AUTOLOGIN=true glab release create v1.0.1 --notes "See CHANGELOG.md" --ref "$CI_COMMIT_SHA"
+
+    # Or use a project/group access token with the api scope
+    $ GITLAB_TOKEN="$ACCESS_TOKEN" glab release create v1.0.1 --notes "See CHANGELOG.md" --ref "$CI_COMMIT_SHA"
+
     # Upload a release asset with a display name (type will default to 'other')                      
     $ glab release create v1.0.1 '/path/to/asset.zip#My display label'                               
                                                                                                      

--- a/glab-release/references/commands.md
+++ b/glab-release/references/commands.md
@@ -4,121 +4,142 @@
 
 ```
 
-  Manage GitLab releases.                                                                                               
-         
-  USAGE  
-         
-    glab release <command> [command] [--flags]  
-            
-  COMMANDS  
-            
+  A release bundles a Git tag with release notes and downloadable
+  assets, such as binaries or source archives.
+
+  Create and update releases, list and view them, upload assets, and
+  download or delete releases. Use `--repo` to target a project other
+  than the current one.
+
+
+  USAGE
+
+    glab release <command> [command] [--flags]
+
+  COMMANDS
+
     create <tag> [<files>...] [--flags]  Create a new GitLab release, or update an existing one.
     delete <tag> [--flags]               Delete a GitLab release.
     download <tag> [--flags]             Download asset files from a GitLab release.
     list [--flags]                       List releases in a repository.
     upload <tag> [<files>...] [--flags]  Upload release asset files or links to a GitLab release.
     view <tag> [--flags]                 View information about a GitLab release.
-         
-  FLAGS  
-         
+
+  FLAGS
+
     -h --help                            Show help for this command.
-    -R --repo                            Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo                            Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+
 ```
 
 ## release create
 
 ```
 
-  Create a new GitLab release for a repository, or                                                                      
-  update an existing one. Requires at least the Developer role.                                                         
-                                                                                                                        
-  An existing release is updated with the new information you provide.                                                  
-                                                                                                                        
-  To create a release from an annotated Git tag:                                                                        
-                                                                                                                        
-  1. Create the tag locally with Git, and push the tag to GitLab.                                                       
-  2. Run this command.                                                                                                  
-  3. If the Git tag you specify doesn't exist, the command creates a                                                    
-     release from the latest state of the default branch, and tags it                                                   
-     with the tag name you specify.                                                                                     
-                                                                                                                        
-     To override this behavior, use `--ref`. The `ref`                                                                  
-     can be a commit SHA, another tag name, or a branch name.                                                           
-  4. Optional. To fetch the new tag locally after the release, run                                                      
-     `git fetch --tags origin`.                                                                                         
-                                                                                                                        
+  Create a new GitLab release for a repository, or
+  update an existing one. Requires at least the Developer role.
+
+  An existing release is updated with the new information you provide.
+
+  To create a release from an annotated Git tag:
+
+  1. Create the tag locally with Git, and push the tag to GitLab.
+  2. Run this command.
+  3. If the Git tag you specify doesn't exist, the command creates a
+     release from the latest state of the default branch, and tags it
+     with the tag name you specify.
+
+     To override this behavior, use `--ref`. The `ref`
+     can be a commit SHA, another tag name, or a branch name.
+  4. Optional. To fetch the new tag locally after the release, run
+     `git fetch --tags origin`.
+
   Authentication in CI/CD:
 
-  - Recommended: Use `CI_JOB_TOKEN` and set `GLAB_ENABLE_CI_AUTOLOGIN=true`. glab sends the token in the `JOB-TOKEN` header, which the Releases API accepts.
-  - Alternative: Use `GITLAB_TOKEN` set to a project or group access token with the `api` scope.
-  - Do not set `GITLAB_TOKEN=$CI_JOB_TOKEN`; the Releases API returns `404 Not Found` because that variable is sent in the `PRIVATE-TOKEN` header.
+  - Recommended: Use `CI_JOB_TOKEN` and turn on CI auto-login by
+    setting `GLAB_ENABLE_CI_AUTOLOGIN=true`. glab sends
+    `CI_JOB_TOKEN` in the `JOB-TOKEN` header, which the Releases
+    API accepts.
+  - Alternative: Use `GITLAB_TOKEN` set to a project or group access token with the
+    `api` scope.
+  - Do not set `GITLAB_TOKEN=$CI_JOB_TOKEN` because the Releases API will
+    return a `404 Not Found`. `GITLAB_TOKEN` is sent as a personal access token in
+    the `PRIVATE-TOKEN` header, which the Releases API does not accept.
 
-         
-  USAGE  
-         
-    glab release create <tag> [<files>...] [--flags]                                                 
-            
-  EXAMPLES  
-            
-    # Create a release interactively                                                                 
-    $ glab release create v1.0.1                                                                     
-                                                                                                     
-    # Create a release non-interactively by specifying a note                                        
-    $ glab release create v1.0.1 --notes "bugfix release"                                            
-                                                                                                     
-    # Use release notes from a file                                                                  
-    $ glab release create v1.0.1 -F changelog.md                                                     
-                                                                                                     
+  The `--publish-to-catalog` flag is an experiment: it might be
+  unstable or removed at any time, and is not ready for production use.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab release create <tag> [<files>...] [--flags]
+
+  EXAMPLES
+
+    # Create a release interactively
+    glab release create v1.0.1
+
+    # Create a release non-interactively by specifying a note
+    glab release create v1.0.1 --notes "bugfix release"
+
+    # Use release notes from a file
+    glab release create v1.0.1 -F changelog.md
+
+    # Update an existing release (e.g., change the release date) without modifying notes
+    glab release create v1.0.1 --released-at "2024-01-15T10:00:00Z"
+
+    # Upload a release asset with a display name (type will default to 'other')
+    glab release create v1.0.1 '/path/to/asset.zip#My display label'
+
+    # Upload a release asset with a display name and type
+    glab release create v1.0.1 '/path/to/asset.png#My display label#image'
+
+    # Upload all assets in a specified folder (types default to 'other')
+    glab release create v1.0.1 ./dist/*
+
+    # Upload all tarballs in a specified folder (types default to 'other')
+    glab release create v1.0.1 ./dist/*.tar.gz
+
     # Create a release from a CI/CD job using the job token
-    $ GLAB_ENABLE_CI_AUTOLOGIN=true glab release create v1.0.1 --notes "See CHANGELOG.md" --ref "$CI_COMMIT_SHA"
+    GLAB_ENABLE_CI_AUTOLOGIN=true glab release create v1.0.1 --notes "See CHANGELOG.md" --ref "$CI_COMMIT_SHA"
 
-    # Or use a project/group access token with the api scope
-    $ GITLAB_TOKEN="$ACCESS_TOKEN" glab release create v1.0.1 --notes "See CHANGELOG.md" --ref "$CI_COMMIT_SHA"
+    # Create a release from a CI/CD job using a project or group access token with the 'api' scope
+    GITLAB_TOKEN="$ACCESS_TOKEN" glab release create v1.0.1 --notes "See CHANGELOG.md" --ref "$CI_COMMIT_SHA"
 
-    # Upload a release asset with a display name (type will default to 'other')                      
-    $ glab release create v1.0.1 '/path/to/asset.zip#My display label'                               
-                                                                                                     
-    # Upload a release asset with a display name and type                                            
-    $ glab release create v1.0.1 '/path/to/asset.png#My display label#image'                         
-                                                                                                     
-    # Upload all assets in a specified folder (types default to 'other')                             
-    $ glab release create v1.0.1 ./dist/*                                                            
-                                                                                                     
-    # Upload all tarballs in a specified folder (types default to 'other')                           
-    $ glab release create v1.0.1 ./dist/*.tar.gz                                                     
-                                                                                                     
-    # Create a release with assets specified as JSON object                                          
-    $ glab release create v1.0.1 --assets-links='                                                    
-    [                                                                                                
-    {                                                                                                
-    "name": "Asset1",                                                                                
-    "url":"https://<domain>/some/location/1",                                                        
-    "link_type": "other",                                                                            
-    "direct_asset_path": "path/to/file"                                                              
-    }                                                                                                
-    ]'                                                                                               
-                                                                                                     
-    # (EXPERIMENTAL) Create a release and publish it to the GitLab CI/CD catalog                     
-    # Requires the feature flag `ci_release_cli_catalog_publish_option` to be enabled                
-    # for this project in your GitLab instance. Do NOT run this manually. Use it as part             
-    # of a CI/CD pipeline with the "release" keyword:                                                
-    #                                                                                                
-    # - It retrieves components from the current repository by searching for                         
-    #   `yml` files within the "templates" directory and its subdirectories.                         
-    # - It fails if the feature flag `ci_release_cli_catalog_publish_option`                         
-    #   is not enabled for this project in your GitLab instance.                                     
-                                                                                                     
-    # Components can be defined:                                                                     
-                                                                                                     
-    # - In single files ending in `.yml` for each component, like `templates/secret-detection.yml`.  
-    # - In subdirectories containing `template.yml` files as entry points,                           
-    #   for components that bundle together multiple related files. For example,                     
-    #   `templates/secret-detection/template.yml`.                                                   
-                                                                                                     
-    $ glab release create v1.0.1 --publish-to-catalog                                                
-         
-  FLAGS  
-         
+    # Create a release with assets specified as JSON object
+    glab release create v1.0.1 --assets-links='
+    [
+    {
+    "name": "Asset1",
+    "url":"https://<domain>/some/location/1",
+    "link_type": "other",
+    "direct_asset_path": "path/to/file"
+    }
+    ]'
+
+    # (EXPERIMENTAL) Create a release and publish it to the GitLab CI/CD catalog
+    # Requires the feature flag `ci_release_cli_catalog_publish_option` to be enabled
+    # for this project in your GitLab instance. Do NOT run this manually. Use it as part
+    # of a CI/CD pipeline with the "release" keyword:
+    #
+    # - It retrieves components from the current repository by searching for
+    #   `yml` files within the "templates" directory and its subdirectories.
+    # - It fails if the feature flag `ci_release_cli_catalog_publish_option`
+    #   is not enabled for this project in your GitLab instance.
+
+    # Components can be defined:
+
+    # - In single files ending in `.yml` for each component, like `templates/secret-detection.yml`.
+    # - In subdirectories containing `template.yml` files as entry points,
+    #   for components that bundle together multiple related files. For example,
+    #   `templates/secret-detection/template.yml`.
+
+    glab release create v1.0.1 --publish-to-catalog
+
+  FLAGS
+
     -a --assets-links       Json string representation of assets links. See documentation for example.
     -h --help               Show help for this command.
     -m --milestone          The title of each milestone the release is associated with. Multiple milestones can be comma-separated or specified by repeating the flag.
@@ -131,37 +152,38 @@
     --publish-to-catalog    (Experimental) Publish the release to the GitLab CI/CD catalog.
     -r --ref                If the specified tag doesn't exist, create a release from the ref and tag it with the specified tag name. Accepts a commit SHA, tag name, or branch name.
     -D --released-at        Iso 8601 datetime when the release was ready. Defaults to the current datetime.
-    -R --repo               Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo               Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
     -T --tag-message        Message to use if creating a new annotated tag.
     --use-package-registry  Upload release assets to the generic package registry of the project. Overrides the GITLAB_RELEASE_ASSETS_USE_PACKAGE_REGISTRY environment variable.
+
 ```
 
 ## release delete
 
 ```
 
-  Delete release assets to GitLab release. Requires the Maintainer role or higher.                                      
-                                                                                                                        
-  Deleting a release does not delete the associated tag, unless you specify `--with-tag`.                               
-                                                                                                                        
-         
-  USAGE  
-         
-    glab release delete <tag> [--flags]              
-            
-  EXAMPLES  
-            
-    # Delete a release (with a confirmation prompt)  
-    $ glab release delete v1.1.0                     
-                                                     
-    # Skip the confirmation prompt and force delete  
-    $ glab release delete v1.0.1 -y                  
-                                                     
-    # Delete release and associated tag              
-    $ glab release delete v1.0.1 --with-tag          
-         
-  FLAGS  
-         
+  Delete release assets to GitLab release. Requires the Maintainer role or higher.
+
+  Deleting a release does not delete the associated tag, unless you specify `--with-tag`.
+
+
+  USAGE
+
+    glab release delete <tag> [--flags]
+
+  EXAMPLES
+
+    # Delete a release (with a confirmation prompt)
+    $ glab release delete v1.1.0
+
+    # Skip the confirmation prompt and force delete
+    $ glab release delete v1.0.1 -y
+
+    # Delete release and associated tag
+    $ glab release delete v1.0.1 --with-tag
+
+  FLAGS
+
     -h --help      Show help for this command.
     -R --repo      Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
     -t --with-tag  Delete the associated tag.
@@ -172,30 +194,30 @@
 
 ```
 
-  Download asset files from a GitLab release.                                                                           
-                                                                                                                        
-  If no tag is specified, downloads assets from the latest release.                                                     
-  To specify a file name to download from the release assets, use `--asset-name`.                                       
-  `--asset-name` flag accepts glob patterns.                                                                            
-                                                                                                                        
-         
-  USAGE  
-         
-    glab release download <tag> [--flags]                    
-            
-  EXAMPLES  
-            
-    # Download all assets from the latest release            
-    $ glab release download                                  
-                                                             
-    # Download all assets from the specified release tag     
-    $ glab release download v1.1.0                           
-                                                             
-    # Download assets with names matching the glob pattern   
-    $ glab release download v1.10.1 --asset-name="*.tar.gz"  
-         
-  FLAGS  
-         
+  Download asset files from a GitLab release.
+
+  If no tag is specified, downloads assets from the latest release.
+  To specify a file name to download from the release assets, use `--asset-name`.
+  `--asset-name` flag accepts glob patterns.
+
+
+  USAGE
+
+    glab release download <tag> [--flags]
+
+  EXAMPLES
+
+    # Download all assets from the latest release
+    $ glab release download
+
+    # Download all assets from the specified release tag
+    $ glab release download v1.1.0
+
+    # Download assets with names matching the glob pattern
+    $ glab release download v1.10.1 --asset-name="*.tar.gz"
+
+  FLAGS
+
     -n --asset-name  Download only assets that match the name or a glob pattern.
     -D --dir         Directory to download the release assets to. (.)
     -h --help        Show help for this command.
@@ -206,14 +228,14 @@
 
 ```
 
-  List releases in a repository.                                                                                        
-         
-  USAGE  
-         
-    glab release list [--flags]  
-         
-  FLAGS  
-         
+  List releases in a repository.
+
+  USAGE
+
+    glab release list [--flags]
+
+  FLAGS
+
     -h --help      Show help for this command.
     -p --page      Page number. (1)
     -P --per-page  Number of items to list per page. (30)
@@ -224,43 +246,43 @@
 
 ```
 
-  Upload release assets to a GitLab release.                                                                            
-                                                                                                                        
-  Define the display name by appending '#' after the filename.                                                          
-  The link type comes after the display name, like this: 'myfile.tar.gz#My display name#package'                        
-                                                                                                                        
-         
-  USAGE  
-         
-    glab release upload <tag> [<files>...] [--flags]                           
-            
-  EXAMPLES  
-            
-    # Upload a release asset with a display name. 'Type' defaults to 'other'.  
-    $ glab release upload v1.0.1 '/path/to/asset.zip#My display label'         
-                                                                               
-    # Upload a release asset with a display name and type.                     
-    $ glab release upload v1.0.1 '/path/to/asset.png#My display label#image'   
-                                                                               
-    # Upload all assets in a specified folder. 'Type' defaults to 'other'.     
-    $ glab release upload v1.0.1 ./dist/*                                      
-                                                                               
-    # Upload all tarballs in a specified folder. 'Type' defaults to 'other'.   
-    $ glab release upload v1.0.1 ./dist/*.tar.gz                               
-                                                                               
-    # Upload release assets links specified as JSON string                     
-    $ glab release upload v1.0.1 --assets-links='                              
-    [                                                                          
-    {                                                                          
-    "name": "Asset1",                                                          
-    "url":"https://<domain>/some/location/1",                                  
-    "link_type": "other",                                                      
-    "direct_asset_path": "path/to/file"                                        
-    }                                                                          
-    ]'                                                                         
-         
-  FLAGS  
-         
+  Upload release assets to a GitLab release.
+
+  Define the display name by appending '#' after the filename.
+  The link type comes after the display name, like this: 'myfile.tar.gz#My display name#package'
+
+
+  USAGE
+
+    glab release upload <tag> [<files>...] [--flags]
+
+  EXAMPLES
+
+    # Upload a release asset with a display name. 'Type' defaults to 'other'.
+    $ glab release upload v1.0.1 '/path/to/asset.zip#My display label'
+
+    # Upload a release asset with a display name and type.
+    $ glab release upload v1.0.1 '/path/to/asset.png#My display label#image'
+
+    # Upload all assets in a specified folder. 'Type' defaults to 'other'.
+    $ glab release upload v1.0.1 ./dist/*
+
+    # Upload all tarballs in a specified folder. 'Type' defaults to 'other'.
+    $ glab release upload v1.0.1 ./dist/*.tar.gz
+
+    # Upload release assets links specified as JSON string
+    $ glab release upload v1.0.1 --assets-links='
+    [
+    {
+    "name": "Asset1",
+    "url":"https://<domain>/some/location/1",
+    "link_type": "other",
+    "direct_asset_path": "path/to/file"
+    }
+    ]'
+
+  FLAGS
+
     -a --assets-links       `Json` string representation of assets links, like: `--assets-links='[{"name": "Asset1", "url":"https://<domain>/some/location/1", "link_type": "other", "direct_asset_path": "path/to/file"}]'.`
     -h --help               Show help for this command.
     --package-name          The package name to use when uploading the assets to the generic package release with --use-package-registry. (release-assets)
@@ -272,27 +294,26 @@
 
 ```
 
-  View information about a GitLab release.                                                                              
-                                                                                                                        
-  Without an explicit tag name argument, shows the latest release in the project.                                       
-                                                                                                                        
-         
-  USAGE  
-         
-    glab release view <tag> [--flags]                 
-            
-  EXAMPLES  
-            
-    # View the latest release of a GitLab repository  
-    $ glab release view                               
-                                                      
-    # View a release with specified tag name          
-    $ glab release view v1.0.1                        
-         
-  FLAGS  
-         
+  View information about a GitLab release.
+
+  Without an explicit tag name argument, shows the latest release in the project.
+
+
+  USAGE
+
+    glab release view <tag> [--flags]
+
+  EXAMPLES
+
+    # View the latest release of a GitLab repository
+    $ glab release view
+
+    # View a release with specified tag name
+    $ glab release view v1.0.1
+
+  FLAGS
+
     -h --help  Show help for this command.
     -R --repo  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
     -w --web   Open the release in the browser.
 ```
-

--- a/glab-securefile/SKILL.md
+++ b/glab-securefile/SKILL.md
@@ -40,6 +40,8 @@ description: Manage secure files for CI/CD including upload, update, download, l
 glab securefile --help
 ```
 
+`glab securefile get` requires GitLab 18.0 or later. On older GitLab instances, list or download by ID/name instead of expecting the details endpoint to work.
+
 ## Removing secure files
 
 Secure-file deletion accepts a positional numeric ID, `--id`, or an exact file name via `--name`:

--- a/glab-securefile/SKILL.md
+++ b/glab-securefile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-securefile
-description: Manage secure files for CI/CD including upload, download, list, and delete operations. Use when storing sensitive files for pipelines, managing certificates, or handling secure configuration files. Triggers on secure file, CI secrets, certificates, secure config.
+description: Manage secure files for CI/CD including upload, update, download, list, and delete operations. Use when storing or replacing sensitive files for pipelines, managing certificates, or handling secure configuration files. Triggers on secure file, CI secrets, certificates, overwrite secure file, secure config.
 ---
 
 # glab securefile
@@ -21,12 +21,12 @@ description: Manage secure files for CI/CD including upload, download, list, and
             
   COMMANDS  
             
-    create <fileName> <inputFilePath>  Create a new project secure file.
-    download <fileID> [--flags]        Download a secure file for a project.
-    get <fileID>                       Get details of a project secure file. (GitLab 18.0 and later)
-    list [--flags]                     List secure files for a project.
-    remove [<fileID> | --id <id> | --name <name>] [--flags]
-                                       Remove a secure file.
+    create <name> <path>                                   Upload a new secure file to a project.
+    download [<id> | --id <id> | --name <name>] [--flags]  Download one or more secure files from a project.
+    get <id> [--flags]                                     Get details of a secure file by ID.
+    list [--flags]                                         List secure files in a project.
+    remove [<id> | --id <id> | --name <name>] [--flags]    Remove a secure file from a project.
+    update <name> <path> [--flags]                         Update a secure file in a project.
          
   FLAGS  
          
@@ -55,6 +55,21 @@ glab securefile remove --name signing-certificate.p12 --yes
 ```
 
 Deletion is permanent. In non-interactive environments, `--yes` / `-y` is required. Resolve and verify the intended project with `-R/--repo` before deleting, and prefer an ID when duplicate or ambiguous naming is possible.
+
+## Updating secure files
+
+Update a secure file by its exact stored name and a local replacement path. The command asks for confirmation unless `--yes` / `-y` is set; `overwrite` is an alias.
+
+```bash
+# Interactive update
+glab securefile update signing-certificate.p12 ./replacement.p12
+
+# Approved non-interactive update in an explicit project
+glab securefile update signing-certificate.p12 ./replacement.p12 \
+  -R group/project --yes
+```
+
+No update occurs when the content is unchanged. A successful update changes the secure file's ID, so subsequent workflows should resolve/download it by `--name` or refresh the ID instead of reusing a stale ID. Confirm the target project, file name, and replacement path before bypassing the prompt.
 
 ## Subcommands
 

--- a/glab-securefile/references/commands.md
+++ b/glab-securefile/references/commands.md
@@ -4,94 +4,120 @@
 
 ```
 
-  Store up to 100 files for secure use in CI/CD pipelines. Secure files are                                             
-  stored outside of your project's repository, not in version control.                                                  
-  It is safe to store sensitive information in these files. Both plain text                                             
-  and binary files are supported, but they must be smaller than 5 MB.                                                   
-                                                                                                                        
-         
-  USAGE  
-         
-    glab securefile <command> [command] [--flags]  
-            
-  COMMANDS  
-            
+  Store up to 100 files for secure use in CI/CD pipelines. Secure files are
+  stored outside of your project's repository, not in version control.
+  It is safe to store sensitive information in these files. Both plain text
+  and binary files are supported, but they must be smaller than 5 MB.
+
+
+  USAGE
+
+    glab securefile <command> [command] [--flags]
+
+  COMMANDS
+
     create <name> <path>                                   Upload a new secure file to a project.
     download [<id> | --id <id> | --name <name>] [--flags]  Download one or more secure files from a project.
     get <id> [--flags]                                     Get details of a secure file by ID.
     list [--flags]                                         List secure files in a project.
     remove [<id> | --id <id> | --name <name>] [--flags]    Remove a secure file from a project.
     update <name> <path> [--flags]                         Update a secure file in a project.
-         
-  FLAGS  
-         
-    -h --help                          Show help for this command.
-    -R --repo                          Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+
+  FLAGS
+
+    -h --help                                              Show help for this command.
+    -R --repo                                              Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+
 ```
 
 ## securefile create
 
 ```
 
-  Create a new project secure file.                                                                                     
-         
-  USAGE  
-         
-    glab securefile create <fileName> <inputFilePath> [--flags]                               
-            
-  EXAMPLES  
-            
-    # Create a project secure file with the given name using the contents of the given path.  
-    $ glab securefile create "newfile.txt" "securefiles/localfile.txt"                        
-                                                                                              
-    # Create a project secure file using the 'upload' alias.                                  
-    $ glab securefile upload "newfile.txt" "securefiles/localfile.txt"                        
-         
-  FLAGS  
-         
+  Provide the name to store the file under, followed by the local path
+  to the file to upload.
+
+  Secure files are stored outside the project's repository and not in
+  version control. Both plain text and binary files are supported, up
+  to a maximum size of 5 MB.
+
+  By default, the file is uploaded to the current project. Use `--repo`
+  to target another project.
+
+
+  USAGE
+
+    glab securefile create <name> <path> [--flags]
+
+  EXAMPLES
+
+    # Upload a secure file from a local path
+    glab securefile create "newfile.txt" "securefiles/localfile.txt"
+
+    # Upload using the 'upload' alias
+    glab securefile upload "newfile.txt" "securefiles/localfile.txt"
+
+    # Upload to another project
+    glab securefile create "newfile.txt" "securefiles/localfile.txt" -R owner/repo
+
+  FLAGS
+
     -h --help  Show help for this command.
-    -R --repo  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+
 ```
 
 ## securefile download
 
 ```
 
-  Download a secure file for a project.                                                                                 
-         
-  USAGE  
-         
-    glab securefile download <fileID> [--flags]                                                  
-            
-  EXAMPLES  
-            
-    # Download a project's secure file using the file's ID by argument or flag.                  
-    $ glab securefile download 1                                                                 
-    $ glab securefile download --id 1                                                            
-                                                                                                 
-    # Download a project's secure file using the file's ID to a given path.                      
-    $ glab securefile download 1 --path="securefiles/file.txt"                                   
-                                                                                                 
-    # Download a project's secure file without verifying its checksum.                           
-    $ glab securefile download 1 --no-verify                                                     
-                                                                                                 
-    # Download a project's secure file even if checksum verification fails.                      
-    $ glab securefile download 1 --force-download                                                
-                                                                                                 
-    # Download a project's secure file using the file's name to the current directory.           
-    $ glab securefile download --name my-secure-file.pem                                         
-                                                                                                 
-    # Download a project's secure file using the file's name to a given path.                    
-    $ glab securefile download --name my-secure-file.pem --path=securefiles/some-other-name.pem  
-                                                                                                 
-    # Download all (limit 100) of a project's secure files.                                      
-    $ glab securefile download --all                                                             
-                                                                                                 
-    # Download all (limit 100) of a project's secure files to a given directory.                 
-    $ glab securefile download --all --output-dir secure_files/                                  
-         
-  FLAGS  
-         
+  To download a single file, identify it by its numeric ID (as a positional
+  argument or with `--id`) or by its name with `--name`. To download every
+  secure file in the project (up to a limit of 100), use `--all`.
+
+  Use `--path` to save a single download to a specific filename, or
+  `--output-dir` to choose the destination directory when downloading
+  multiple files.
+
+  By default, downloaded files are verified against their checksum.
+  Use `--no-verify` to skip verification, or `--force-download` to keep
+  files even when verification fails. Both options can allow corrupted
+  or tampered files; use with caution.
+
+  By default, files are downloaded from the current project. Use
+  `--repo` to target another project.
+
+
+  USAGE
+
+    glab securefile download [<id> | --id <id> | --name <name>] [--flags]
+
+  EXAMPLES
+
+    # Download a file by ID (positional or flag)
+    glab securefile download 1
+    glab securefile download --id 1
+
+    # Download a file by ID to a specific path
+    glab securefile download 1 --path "securefiles/file.txt"
+
+    # Download a file by name to the current directory
+    glab securefile download --name my-secure-file.pem
+
+    # Download a file by name to a chosen path
+    glab securefile download --name my-secure-file.pem --path securefiles/some-other-name.pem
+
+    # Download without verifying the checksum
+    glab securefile download 1 --no-verify
+
+    # Download all secure files in the project (up to 100)
+    glab securefile download --all
+
+    # Download all secure files to a specific directory
+    glab securefile download --all --output-dir secure_files/
+
+  FLAGS
+
     --all             Download all (limit 100) of a project's secure files. Files are downloaded with their original name and file extension.
     --force-download  Force download file(s) even if checksum verification fails. Warning: when enabled, this setting allows the download of files that are corrupt or tampered with.
     -h --help         Show help for this command.
@@ -100,63 +126,87 @@
     --no-verify       Do not verify the checksum of the downloaded file(s). Warning: when enabled, this setting allows the download of files that are corrupt or tampered with.
     --output-dir      Output directory for files downloaded with --all. (.)
     -p --path         Path to download the secure file to, including filename and extension. (./downloaded.tmp)
-    -R --repo         Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo         Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+
 ```
 
 ## securefile get
 
 ```
 
-  Get details of a project secure file. (GitLab 18.0 and later)                                                         
-         
-  USAGE  
-         
-    glab securefile get <fileID> [--flags]                            
-            
-  EXAMPLES  
-            
-    # Get details of a project's secure file using the file ID.       
-    $ glab securefile get 1                                           
-                                                                      
-    # Get details of a project's secure file using the 'show' alias.  
-    $ glab securefile show 1                                          
-         
-  FLAGS  
-         
+  Get details of a single secure file in a project, identified by its
+  numeric ID. The response includes the file's name, checksum, and
+  associated metadata.
+
+  This command requires GitLab 18.0 or later.
+
+  By default, the file is looked up in the current project. Use
+  `--repo` to target another project.
+
+
+  USAGE
+
+    glab securefile get <id> [--flags]
+
+  EXAMPLES
+
+    # Get details of a secure file by ID
+    glab securefile get 1
+
+    # Get details using the 'show' alias
+    glab securefile show 1
+
+    # Get details from another project
+    glab securefile get 1 -R owner/repo
+
+  FLAGS
+
     -h --help  Show help for this command.
-    -R --repo  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    --jq       Filter JSON output with a jq expression.
+    -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+
 ```
 
 ## securefile list
 
 ```
 
-  List secure files for a project.                                                                                      
-         
-  USAGE  
-         
-    glab securefile list [--flags]                                  
-            
-  EXAMPLES  
-            
-    List all secure files.                                          
-    - glab securefile list                                          
-                                                                    
-    List all secure files with 'cmd' alias.                         
-    - glab securefile ls                                            
-                                                                    
-    List a specific page of secure files.                           
-    - glab securefile list --page 2                                 
-                                                                    
-    List a specific page of secure files, with a custom page size.  
-    - glab securefile list --page 2 --per-page 10                   
-         
-  FLAGS  
-         
+  List the secure files configured for a project. Use `--page` and
+  `--per-page` to paginate the result.
+
+  By default, files are listed for the current project. Use `--repo`
+  to target another project.
+
+
+  USAGE
+
+    glab securefile list [--flags]
+
+  EXAMPLES
+
+    # List all secure files in the current project
+    glab securefile list
+
+    # Use the 'ls' alias
+    glab securefile ls
+
+    # List a specific page
+    glab securefile list --page 2
+
+    # List a specific page with a custom page size
+    glab securefile list --page 2 --per-page 10
+
+    # List files from another project
+    glab securefile list -R owner/repo
+
+  FLAGS
+
     -h --help      Show help for this command.
+    --jq           Filter JSON output with a jq expression.
     -p --page      Page number. (1)
     -P --per-page  Number of items to list per page. (30)
-    -R --repo      Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo      Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+
 ```
 
 ## securefile remove
@@ -200,28 +250,39 @@ INHERITED FLAGS
 ## securefile update
 
 ```
-Update a secure file in a project, identified by its name. The command asks for confirmation before updating; use `-y` to skip the prompt in scripts.
 
-By default, the file is updated in the current project. Use `--repo` to target another project. If the file content is unchanged, no update is performed.
+  Update a secure file in a project, identified by its name.
+  The command asks for confirmation before updating; use `-y` to skip
+  the prompt in scripts.
 
-Updating a secure file changes its ID. When you download the file afterward, reference it by `--name` instead of `--id`.
+  By default, the file is updated in the current project. Use `--repo`
+  to target another project.
 
-USAGE
-  glab securefile update <name> <path> [--flags]
+  If the file content is unchanged, no update is performed.
 
-ALIASES
-  overwrite
+  Updating a secure file changes its ID. When you download the file afterward, reference it by `--name` instead of `--
+  id`.
 
-EXAMPLES
-  glab securefile update "file.txt" securefiles/localfile.txt
-  glab securefile update "file.txt" securefiles/localfile.txt -y
-  glab securefile overwrite "file.txt" securefiles/localfile.txt
 
-FLAGS
-  -y, --yes          Skip the confirmation prompt.
+  USAGE
 
-INHERITED FLAGS
-  -h, --help         Show help for this command.
-  -R, --repo string  Select another repository. OWNER/REPO, GROUP/NAMESPACE/REPO, full URL, and Git URL are accepted.
+    glab securefile update <name> <path> [--flags]
+
+  EXAMPLES
+
+    # Update a secure file
+    glab securefile update "file.txt" securefiles/localfile.txt
+
+    # Skip the confirmation prompt
+    glab securefile update "file.txt" securefiles/localfile.txt -y
+
+    # Use the 'overwrite' alias
+    glab securefile overwrite "file.txt" securefiles/localfile.txt
+
+  FLAGS
+
+    -h --help  Show help for this command.
+    -R --repo  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+    -y --yes   Skip the confirmation prompt.
+
 ```
-

--- a/glab-securefile/references/commands.md
+++ b/glab-securefile/references/commands.md
@@ -1,6 +1,6 @@
 # glab securefile help
 
-> Help output captured from `glab securefile --help`.
+> Help output captured from `glab securefile --help` and its subcommands.
 
 ```
 
@@ -16,12 +16,12 @@
             
   COMMANDS  
             
-    create <fileName> <inputFilePath>  Create a new project secure file.
-    download <fileID> [--flags]        Download a secure file for a project.
-    get <fileID>                       Get details of a project secure file. (GitLab 18.0 and later)
-    list [--flags]                     List secure files for a project.
-    remove [<fileID> | --id <id> | --name <name>] [--flags]
-                                       Remove a secure file.
+    create <name> <path>                                   Upload a new secure file to a project.
+    download [<id> | --id <id> | --name <name>] [--flags]  Download one or more secure files from a project.
+    get <id> [--flags]                                     Get details of a secure file by ID.
+    list [--flags]                                         List secure files in a project.
+    remove [<id> | --id <id> | --name <name>] [--flags]    Remove a secure file from a project.
+    update <name> <path> [--flags]                         Update a secure file in a project.
          
   FLAGS  
          
@@ -190,6 +190,34 @@ EXAMPLES
 FLAGS
       --id int       ID of the secure file to remove.
       --name string  Name of the secure file to remove.
+  -y, --yes          Skip the confirmation prompt.
+
+INHERITED FLAGS
+  -h, --help         Show help for this command.
+  -R, --repo string  Select another repository. OWNER/REPO, GROUP/NAMESPACE/REPO, full URL, and Git URL are accepted.
+```
+
+## securefile update
+
+```
+Update a secure file in a project, identified by its name. The command asks for confirmation before updating; use `-y` to skip the prompt in scripts.
+
+By default, the file is updated in the current project. Use `--repo` to target another project. If the file content is unchanged, no update is performed.
+
+Updating a secure file changes its ID. When you download the file afterward, reference it by `--name` instead of `--id`.
+
+USAGE
+  glab securefile update <name> <path> [--flags]
+
+ALIASES
+  overwrite
+
+EXAMPLES
+  glab securefile update "file.txt" securefiles/localfile.txt
+  glab securefile update "file.txt" securefiles/localfile.txt -y
+  glab securefile overwrite "file.txt" securefiles/localfile.txt
+
+FLAGS
   -y, --yes          Skip the confirmation prompt.
 
 INHERITED FLAGS

--- a/glab-variable/SKILL.md
+++ b/glab-variable/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-variable
-description: Manage CI/CD variables at project and group level including create, update, list, and delete operations. Use when setting environment variables for pipelines, managing secrets, or configuring CI/CD variables. Triggers on variable, CI variable, environment variable, secrets, CI/CD config.
+description: Manage CI/CD variables at project and group level including create, update, import, export, list, and delete operations. Use when setting environment variables for pipelines, managing secrets, migrating variables, or configuring CI/CD variables. Triggers on variable, CI variable, environment variable, secrets, variable import, CI/CD config.
 ---
 
 # glab variable
@@ -9,7 +9,10 @@ description: Manage CI/CD variables at project and group level including create,
 
 ```
 
-  Manage variables for a GitLab project or group.                                                                       
+  Variables store configuration and secrets used by CI/CD pipelines.
+
+  Each subcommand acts on the current project by default. Use
+  `--group` to manage a group's variables instead.
          
   USAGE  
          
@@ -20,6 +23,7 @@ description: Manage CI/CD variables at project and group level including create,
     delete <key> [--flags]          Delete a variable for a project or group.
     export [--flags]                Export variables from a project or group.
     get <key> [--flags]             Get a variable for a project or group.
+    import [--flags]                Import variables from a JSON file or standard input.
     list [--flags]                  List variables for a project or group.
     set <key> <value> [--flags]     Create a new variable for a project or group.
     update <key> <value> [--flags]  Update an existing variable for a project or group.
@@ -35,6 +39,25 @@ description: Manage CI/CD variables at project and group level including create,
 ```bash
 glab variable --help
 ```
+
+## Export and import variables
+
+`glab variable import` consumes the same JSON array shape emitted by `glab variable export --output json`. It reads standard input by default or a file passed with `--input-file` / `-i`.
+
+```bash
+# Preview and preserve an export before importing it elsewhere
+glab variable export --output json > variables.json
+glab variable import --input-file variables.json -R group/target-project
+
+# Pipe between groups
+glab variable export --group source-group |
+  glab variable import --group target-group
+
+# Continue when target variables already exist
+glab variable import --input-file variables.json --skip-existing
+```
+
+Import stops when a target variable already exists unless `--skip-existing` is set. Hidden variable values are omitted from exports, so those entries are skipped with a warning during import; recreate their values explicitly with `glab variable set --hidden` from an approved secret source. Treat export files as sensitive, keep them out of version control, and verify the target project or group before importing.
 
 ## Subcommands
 

--- a/glab-variable/references/commands.md
+++ b/glab-variable/references/commands.md
@@ -8,13 +8,13 @@
 
   Each subcommand acts on the current project by default. Use
   `--group` to manage a group's variables instead.
-         
-  USAGE  
-         
-    glab variable [command] [--flags]  
-            
-  COMMANDS  
-            
+
+  USAGE
+
+    glab variable [command] [--flags]
+
+  COMMANDS
+
     delete <key> [--flags]          Delete a variable for a project or group.
     export [--flags]                Export variables from a project or group.
     get <key> [--flags]             Get a variable for a project or group.
@@ -22,9 +22,9 @@
     list [--flags]                  List variables for a project or group.
     set <key> <value> [--flags]     Create a new variable for a project or group.
     update <key> <value> [--flags]  Update an existing variable for a project or group.
-         
-  FLAGS  
-         
+
+  FLAGS
+
     -h --help                       Show help for this command.
     -R --repo                       Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
 ```
@@ -33,20 +33,20 @@
 
 ```
 
-  Delete a variable for a project or group.                                                                             
-         
-  USAGE  
-         
-    glab variable delete <key> [--flags]          
-            
-  EXAMPLES  
-            
-    $ glab variable delete VAR_NAME               
-    $ glab variable delete VAR_NAME --scope=prod  
-    $ glab variable delete VARNAME -g mygroup     
-         
-  FLAGS  
-         
+  Delete a variable for a project or group.
+
+  USAGE
+
+    glab variable delete <key> [--flags]
+
+  EXAMPLES
+
+    $ glab variable delete VAR_NAME
+    $ glab variable delete VAR_NAME --scope=prod
+    $ glab variable delete VARNAME -g mygroup
+
+  FLAGS
+
     -g --group  Delete variable from a group.
     -h --help   Show help for this command.
     -R --repo   Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
@@ -57,51 +57,57 @@
 
 ```
 
-  Export variables from a project or group.                                                                             
-         
-  USAGE  
-         
-    glab variable export [--flags]                                      
-            
-  EXAMPLES  
-            
-    $ glab variable export                                              
-    $ glab variable export --per-page 1000 --page 1                     
-    $ glab variable export --group gitlab-org                           
-    $ glab variable export --group gitlab-org --per-page 1000 --page 1  
-    $ glab variable export --output json                                
-    $ glab variable export --output env                                 
-    $ glab variable export --output export                              
-         
-  FLAGS  
-         
+  Defaults to the current project. Use `--group` to export
+  variables for a group. Use `--output` to set the format:
+  `json` (default), `env` (KEY=VALUE pairs), or
+  `export` (shell export statements).
+
+
+  USAGE
+
+    glab variable export [--flags]
+
+  EXAMPLES
+
+    glab variable export
+    glab variable export --per-page 1000 --page 1
+    glab variable export --group gitlab-org
+    glab variable export --group gitlab-org --per-page 1000 --page 1
+    glab variable export --output json
+    glab variable export --output env
+    glab variable export --output export
+
+  FLAGS
+
     -g --group     Select a group or subgroup. Ignored if a repository argument is set.
     -h --help      Show help for this command.
+    --jq           Filter JSON output with a jq expression.
     -F --output    Format output as: json, export, env. (json)
     -p --page      Page number. (1)
     -P --per-page  Number of items to list per page. (100)
-    -R --repo      Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo      Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
     -s --scope     The environment_scope of the variables. Values: '*' (default), or specific environments. (*)
+
 ```
 
 ## variable get
 
 ```
 
-  Get a variable for a project or group.                                                                                
-         
-  USAGE  
-         
-    glab variable get <key> [--flags]     
-            
-  EXAMPLES  
-            
-    $ glab variable get VAR_KEY           
-    $ glab variable get -g GROUP VAR_KEY  
-    $ glab variable get -s SCOPE VAR_KEY  
-         
-  FLAGS  
-         
+  Get a variable for a project or group.
+
+  USAGE
+
+    glab variable get <key> [--flags]
+
+  EXAMPLES
+
+    $ glab variable get VAR_KEY
+    $ glab variable get -g GROUP VAR_KEY
+    $ glab variable get -s SCOPE VAR_KEY
+
+  FLAGS
+
     -g --group   Get variable for a group.
     -h --help    Show help for this command.
     -F --output  Format output as: text, json. (text)
@@ -112,54 +118,71 @@
 ## variable import
 
 ```
-The inverse of `glab variable export`. Reads a JSON array of variable objects, in the same shape `export --output json` emits.
 
-The command:
-- Reads from standard input, or from a file with `--input-file`.
-- Imports into the current project by default. Use `--group` to import into a group instead.
-- Stops with an error if a variable already exists. Pass `--skip-existing` to skip those and continue.
+  The inverse of `glab variable export`. Reads a JSON array of
+  variable objects, in the same shape `export --output json` emits.
 
-Hidden variables' values aren't included in `export` output, so re-importing one is skipped with a warning. Set its value again with `glab variable set --hidden`.
+  The command:
 
-USAGE
-  glab variable import [--flags]
+  - Reads from standard input, or from a file with `--input-file`.
+  - Imports into the current project by default. Use `--group` to
+    import into a group instead.
+  - Stops with an error if a variable already exists. Pass
+    `--skip-existing` to skip those and continue.
 
-ALIASES
-  im
+  Hidden variables' values aren't included in `export` output,
+  so re-importing one is skipped with a warning. Set its value again
+  with `glab variable set --hidden`.
 
-EXAMPLES
-  glab variable export | glab variable import
-  glab variable import --input-file variables.json
-  glab variable export --group gitlab-org | glab variable import --group gitlab-org
-  glab variable import --input-file variables.json --skip-existing
 
-FLAGS
-  -g, --group string       Select a group or subgroup. Ignored if a repository argument is set.
-  -i, --input-file string  Read the variables JSON from this file instead of standard input.
-  -R, --repo string        Select another repository. OWNER/REPO, GROUP/NAMESPACE/REPO, full URL, and Git URL are accepted.
-      --skip-existing      Skip variables that already exist instead of failing.
+  USAGE
+
+    glab variable import [--flags]
+
+  EXAMPLES
+
+    # Pipe an export straight into an import, to restore the same project
+    glab variable export | glab variable import
+
+    # Import variables from a saved file instead of standard input
+    glab variable import --input-file variables.json
+
+    # Import into a group instead of the current project
+    glab variable export --group gitlab-org | glab variable import --group gitlab-org
+
+    # Skip variables that already exist instead of failing
+    glab variable import --input-file variables.json --skip-existing
+
+  FLAGS
+
+    -g --group       Select a group or subgroup. Ignored if a repository argument is set.
+    -h --help        Show help for this command.
+    -i --input-file  Read the variables JSON from this file instead of standard input.
+    -R --repo        Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+    --skip-existing  Skip variables that already exist instead of failing.
+
 ```
 
 ## variable list
 
 ```
 
-  List variables for a project or group.                                                                                
-         
-  USAGE  
-         
-    glab variable list [--flags]                            
-            
-  EXAMPLES  
-            
-    $ glab variable list                                    
-    $ glab variable list -i                                 
-    $ glab variable list --per-page 100 --page 1            
-    $ glab variable list --group gitlab-org                 
-    $ glab variable list --group gitlab-org --per-page 100  
-         
-  FLAGS  
-         
+  List variables for a project or group.
+
+  USAGE
+
+    glab variable list [--flags]
+
+  EXAMPLES
+
+    $ glab variable list
+    $ glab variable list -i
+    $ glab variable list --per-page 100 --page 1
+    $ glab variable list --group gitlab-org
+    $ glab variable list --group gitlab-org --per-page 100
+
+  FLAGS
+
     -g --group     Select a group or subgroup. Ignored if a repository argument is set.
     -h --help      Show help for this command.
     -i --instance  Display instance variables.
@@ -173,25 +196,25 @@ FLAGS
 
 ```
 
-  Create a new variable for a project or group.                                                                         
-         
-  USAGE  
-         
-    glab variable set <key> <value> [--flags]                                    
-            
-  EXAMPLES  
-            
-    $ glab variable set WITH_ARG "some value"                                    
-    $ glab variable set WITH_DESC "some value" --description "some description"  
-    $ glab variable set FROM_FLAG -v "some value"                                
-    $ glab variable set FROM_ENV_WITH_ARG "${ENV_VAR}"                           
-    $ glab variable set FROM_ENV_WITH_FLAG -v"${ENV_VAR}"                        
-    $ glab variable set FROM_FILE < secret.txt                                   
-    $ cat file.txt | glab variable set SERVER_TOKEN                              
-    $ cat token.txt | glab variable set GROUP_TOKEN -g mygroup --scope=prod      
-         
-  FLAGS  
-         
+  Create a new variable for a project or group.
+
+  USAGE
+
+    glab variable set <key> <value> [--flags]
+
+  EXAMPLES
+
+    $ glab variable set WITH_ARG "some value"
+    $ glab variable set WITH_DESC "some value" --description "some description"
+    $ glab variable set FROM_FLAG -v "some value"
+    $ glab variable set FROM_ENV_WITH_ARG "${ENV_VAR}"
+    $ glab variable set FROM_ENV_WITH_FLAG -v"${ENV_VAR}"
+    $ glab variable set FROM_FILE < secret.txt
+    $ cat file.txt | glab variable set SERVER_TOKEN
+    $ cat token.txt | glab variable set GROUP_TOKEN -g mygroup --scope=prod
+
+  FLAGS
+
     -d --description  Set description of a variable.
     -g --group        Set variable for a group.
     -h --help         Show help for this command.
@@ -209,24 +232,24 @@ FLAGS
 
 ```
 
-  Update an existing variable for a project or group.                                                                   
-         
-  USAGE  
-         
-    glab variable update <key> <value> [--flags]                                
-            
-  EXAMPLES  
-            
-    $ glab variable update WITH_ARG "some value"                                
-    $ glab variable update FROM_FLAG -v "some value"                            
-    $ glab variable update FROM_ENV_WITH_ARG "${ENV_VAR}"                       
-    $ glab variable update FROM_ENV_WITH_FLAG -v"${ENV_VAR}"                    
-    $ glab variable update FROM_FILE < secret.txt                               
-    $ cat file.txt | glab variable update SERVER_TOKEN                          
-    $ cat token.txt | glab variable update GROUP_TOKEN -g mygroup --scope=prod  
-         
-  FLAGS  
-         
+  Update an existing variable for a project or group.
+
+  USAGE
+
+    glab variable update <key> <value> [--flags]
+
+  EXAMPLES
+
+    $ glab variable update WITH_ARG "some value"
+    $ glab variable update FROM_FLAG -v "some value"
+    $ glab variable update FROM_ENV_WITH_ARG "${ENV_VAR}"
+    $ glab variable update FROM_ENV_WITH_FLAG -v"${ENV_VAR}"
+    $ glab variable update FROM_FILE < secret.txt
+    $ cat file.txt | glab variable update SERVER_TOKEN
+    $ cat token.txt | glab variable update GROUP_TOKEN -g mygroup --scope=prod
+
+  FLAGS
+
     -d --description  Set description of a variable.
     -g --group        Set variable for a group.
     -h --help         Show help for this command.
@@ -238,4 +261,3 @@ FLAGS
     -t --type         The type of a variable: env_var, file. (env_var)
     -v --value        The value of a variable.
 ```
-

--- a/glab-variable/references/commands.md
+++ b/glab-variable/references/commands.md
@@ -1,10 +1,13 @@
 # glab variable help
 
-> Help output captured from `glab variable --help`.
+> Help output captured from `glab variable --help` and its subcommands.
 
 ```
 
-  Manage variables for a GitLab project or group.                                                                       
+  Variables store configuration and secrets used by CI/CD pipelines.
+
+  Each subcommand acts on the current project by default. Use
+  `--group` to manage a group's variables instead.
          
   USAGE  
          
@@ -15,6 +18,7 @@
     delete <key> [--flags]          Delete a variable for a project or group.
     export [--flags]                Export variables from a project or group.
     get <key> [--flags]             Get a variable for a project or group.
+    import [--flags]                Import variables from a JSON file or standard input.
     list [--flags]                  List variables for a project or group.
     set <key> <value> [--flags]     Create a new variable for a project or group.
     update <key> <value> [--flags]  Update an existing variable for a project or group.
@@ -103,6 +107,37 @@
     -F --output  Format output as: text, json. (text)
     -R --repo    Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
     -s --scope   The environment_scope of the variable. Values: all (*), or specific environments. (*)
+```
+
+## variable import
+
+```
+The inverse of `glab variable export`. Reads a JSON array of variable objects, in the same shape `export --output json` emits.
+
+The command:
+- Reads from standard input, or from a file with `--input-file`.
+- Imports into the current project by default. Use `--group` to import into a group instead.
+- Stops with an error if a variable already exists. Pass `--skip-existing` to skip those and continue.
+
+Hidden variables' values aren't included in `export` output, so re-importing one is skipped with a warning. Set its value again with `glab variable set --hidden`.
+
+USAGE
+  glab variable import [--flags]
+
+ALIASES
+  im
+
+EXAMPLES
+  glab variable export | glab variable import
+  glab variable import --input-file variables.json
+  glab variable export --group gitlab-org | glab variable import --group gitlab-org
+  glab variable import --input-file variables.json --skip-existing
+
+FLAGS
+  -g, --group string       Select a group or subgroup. Ignored if a repository argument is set.
+  -i, --input-file string  Read the variables JSON from this file instead of standard input.
+  -R, --repo string        Select another repository. OWNER/REPO, GROUP/NAMESPACE/REPO, full URL, and Git URL are accepted.
+      --skip-existing      Skip variables that already exist instead of failing.
 ```
 
 ## variable list


### PR DESCRIPTION
## Upstream source

- GitLab CLI `glab` **v1.109.0**
- Canonical release: https://gitlab.com/gitlab-org/cli/-/releases/v1.109.0
- Canonical release API: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/v1.109.0
- Upstream commit: `757294c01143360b466a70daf3fbef869fc3a41b`

## Relevant CLI changes

- Added `glab variable import` for export-shaped JSON from stdin or `--input-file`, with group targeting and `--skip-existing`.
- Added `glab securefile update` / `overwrite`; unchanged content is a no-op and successful replacement changes the secure-file ID.
- Documented XDG configuration search precedence.
- Documented correct GitLab CI authentication for `glab release create` (`CI_JOB_TOKEN` + `GLAB_ENABLE_CI_AUTOLOGIN=true`, rather than assigning a job token to `GITLAB_TOKEN`).
- Reviewed the unauthenticated API-header fix, dependency-firewall foundations, and generated-doc pruning; no additional skill changes were needed for those items.

## Skill/package changes

- Bumped package metadata to `1.13.18` in `VERSION`.
- Updated `glab-variable`, `glab-securefile`, `glab-config`, and `glab-release` operational guidance and command references.
- Kept upstream CLI version history in `VERSION`; individual `SKILL.md` files remain current operational guidance.
- Rebuilt the Claude.ai merged skill artifact locally (the release zip is not tracked in git).

## Validation

- Official macOS arm64 archive SHA-256 matched GitLab's published checksum: `e3c2dfeb96ebe8756273a0a04b7efbadf9eee7731cccc3882bfc03b2dc151cbf`.
- Binary smoke check: `glab 1.109.0 (757294c0)`.
- Captured and checked current help for variable import, secure-file update, config, and release create.
- `git diff --check` passed.
- `bash scripts/build-claude-skill.sh` merged 45 sub-skills plus the orchestrator (5,557 lines).
- Zip validation passed: exactly one `SKILL.md` at `gitlab-cli-skills/SKILL.md`.
- Merged artifact contains the new variable-import, secure-file-update, XDG, and CI release-auth guidance.
- `npx skills add . --list` discovered all 46 skills.

## Review request

**Vince: please review this refresh before merge.** This PR is intentionally not merged by the Hermes refresh job.
