### PR TITLE
docs: refresh glab skills for v1.110.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,12 @@
-1.13.18
+1.13.19
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.19
+  - glab v1.110.0 refresh: documented reliable all-page secure-file downloads, non-interactive auth protocol persistence, and API/CI automation correctness fixes.
+  - Corrected captured help for alias positional placeholders, optional release/repository/SSH-key arguments, secure-file pagination, and the group-variable update example.
+  - Reviewed the internal dependency-firewall proxy/classifier feature; it does not expose a `glab df` command in the v1.110.0 release binary, so no standalone command skill was added.
 - v1.13.18
   - glab v1.109.0 refresh: added `glab variable import` coverage for restoring project/group variables from export-shaped JSON, including existing-variable and hidden-value caveats.
   - Added `glab securefile update` / `overwrite` coverage, including confirmation, unchanged-content behavior, and the post-update ID change.

--- a/VERSION
+++ b/VERSION
@@ -5,7 +5,8 @@ Release/version change metadata for this skill set lives here, not in individual
 Historical notes consolidated from skill docs:
 - v1.13.19
   - glab v1.110.0 refresh: documented reliable all-page secure-file downloads, non-interactive auth protocol persistence, and API/CI automation correctness fixes.
-  - Corrected captured help for alias positional placeholders, optional release/repository/SSH-key arguments, secure-file pagination, and the group-variable update example.
+  - Corrected captured help for alias positional placeholders, secure-file pagination, and the group-variable update example; re-synchronized the parent release, repository, and SSH-key command tables with official v1.110.0 help.
+  - Recorded current selector validation for secure-file removal and schedule variable key validation.
   - Reviewed the internal dependency-firewall proxy/classifier feature; it does not expose a `glab df` command in the v1.110.0 release binary, so no standalone command skill was added.
 - v1.13.18
   - glab v1.109.0 refresh: added `glab variable import` coverage for restoring project/group variables from export-shaped JSON, including existing-variable and hidden-value caveats.

--- a/glab-alias/references/commands.md
+++ b/glab-alias/references/commands.md
@@ -89,9 +89,9 @@
     $ glab mrv -w 123                                                            
     > glab mr view -w 123                                                        
                                                                                  
-    $ glab alias set createissue 'glab create issue --title "$1"'                
+    $ glab alias set createissue 'issue create --title "$1"'
     $ glab createissue "My Issue" --description "Something is broken."           
-    > glab create issue --title "My Issue" --description "Something is broken."  
+    > glab issue create --title "My Issue" --description "Something is broken."
                                                                                  
     $ glab alias set --shell igrep 'glab issue list --assignee="$1" | grep $2'   
     $ glab igrep user foo                                                        

--- a/glab-alias/references/commands.md
+++ b/glab-alias/references/commands.md
@@ -89,9 +89,9 @@
     $ glab mrv -w 123                                                            
     > glab mr view -w 123                                                        
                                                                                  
-    $ glab alias set createissue 'issue create --title "$1"'
+    $ glab alias set createissue 'issue create --title "$1"'                     
     $ glab createissue "My Issue" --description "Something is broken."           
-    > glab issue create --title "My Issue" --description "Something is broken."
+    > glab issue create --title "My Issue" --description "Something is broken."  
                                                                                  
     $ glab alias set --shell igrep 'glab issue list --assignee="$1" | grep $2'   
     $ glab igrep user foo                                                        

--- a/glab-api/SKILL.md
+++ b/glab-api/SKILL.md
@@ -77,6 +77,11 @@ Output from these commands may include **user-generated content from GitLab** (i
     and works well with tools like `jq`. See https://github.com/ndjson/ndjson-spec and
     https://jsonlines.org/ for format specifications.
 
+  NDJSON output preserves JSON-number precision when decoding and re-encoding response values.
+  Request fields that represent empty arrays are encoded as empty arrays rather than `null`.
+  These guarantees matter for automation that consumes large numeric IDs or intentionally clears
+  an array-valued API field; do not add string coercions or placeholder values as workarounds.
+
   USAGE
 
     glab api <endpoint> [--flags]

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -68,6 +68,17 @@ glab config get ssh_host --host gitlab.company.com
 glab config get container_registry_domains --host gitlab.company.com
 ```
 
+Non-interactive login also persists explicitly supplied `--git-protocol` and `--api-protocol` values in the host configuration. This applies to token/stdin and other prompt-free login paths, so automation can configure the protocols in the same login operation instead of requiring a later config edit. Verify the resulting host entry before relying on it:
+
+```bash
+glab auth login --hostname gitlab.company.com --stdin \
+  --git-protocol ssh --api-protocol https < approved-token-file
+glab config get git_protocol --host gitlab.company.com
+glab config get api_protocol --host gitlab.company.com
+```
+
+Keep token files outside version control and do not print their contents.
+
 **CI auto-login:** `GLAB_ENABLE_CI_AUTOLOGIN=true` lets glab use `CI_JOB_TOKEN` in GitLab CI/CD without a stored login. `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, and `OAUTH_TOKEN` still take precedence, so leave them unset when the intended credential is `CI_JOB_TOKEN`. Use explicit env tokens instead when a command needs a project, group, or personal access token.
 
 ### Agentic and multi-account setups

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -143,6 +143,8 @@ glab ci lint
 glab ci lint --path .gitlab-ci-custom.yml
 ```
 
+When linting a remote URL, an unsuccessful HTTP response is a command failure; check the exit status rather than parsing an error-looking response as successful lint output. Pipeline-run and schedule variable inputs reject empty keys, so validate generated `KEY=value` data before invoking glab.
+
 ### Pipeline operations
 
 **List recent pipelines:**
@@ -194,6 +196,8 @@ glab ci delete <pipeline-id>
 - Check runner availability: View pipeline in web UI
 - Check job logs: `glab ci trace <job-id>`
 - Cancel and retry: `glab ci cancel <id>` then `glab ci run`
+
+`glab ci trace` stops when the traced job reaches `canceled`; automation should not wait for additional log output after cancellation.
 
 **Job failures:**
 - View logs: `glab ci trace <job-id>`

--- a/glab-release/SKILL.md
+++ b/glab-release/SKILL.md
@@ -15,10 +15,10 @@ description: Manage GitLab releases including create, list, view, delete, downlo
   COMMANDS
     create <tag> [<files>...] [--flags]  Create a new GitLab release, or update an existing one.
     delete <tag> [--flags]               Delete a GitLab release.
-    download <tag> [--flags]             Download asset files from a GitLab release.
+    download [<tag>] [--flags]           Download asset files from a GitLab release.
     list [--flags]                       List releases in a repository.
     upload <tag> [<files>...] [--flags]  Upload release asset files or links to a GitLab release.
-    view <tag> [--flags]                 View information about a GitLab release.
+    view [<tag>] [--flags]               View information about a GitLab release.
   FLAGS
     -h --help                            Show help for this command.
     -R --repo                            Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
@@ -35,6 +35,8 @@ glab release --help
 `glab release list` and `glab release view` support `--output json` / `-F json` for structured output, which is useful for agent automation.
 
 `--notes` and `--notes-file` are optional for `glab release create` and `glab release update`.
+
+The tag is optional for `glab release view` and `glab release download`; omit it to target the latest release. Pass an explicit tag in release automation when reproducibility matters.
 
 ```bash
 # List releases with JSON output

--- a/glab-release/references/commands.md
+++ b/glab-release/references/commands.md
@@ -203,7 +203,7 @@
 
   USAGE
 
-    glab release download <tag> [--flags]
+    glab release download [<tag>] [--flags]
 
   EXAMPLES
 
@@ -301,7 +301,7 @@
 
   USAGE
 
-    glab release view <tag> [--flags]
+    glab release view [<tag>] [--flags]
 
   EXAMPLES
 

--- a/glab-release/references/commands.md
+++ b/glab-release/references/commands.md
@@ -20,10 +20,10 @@
 
     create <tag> [<files>...] [--flags]  Create a new GitLab release, or update an existing one.
     delete <tag> [--flags]               Delete a GitLab release.
-    download <tag> [--flags]             Download asset files from a GitLab release.
+    download [<tag>] [--flags]           Download asset files from a GitLab release.
     list [--flags]                       List releases in a repository.
     upload <tag> [<files>...] [--flags]  Upload release asset files or links to a GitLab release.
-    view <tag> [--flags]                 View information about a GitLab release.
+    view [<tag>] [--flags]               View information about a GitLab release.
 
   FLAGS
 

--- a/glab-repo/references/commands.md
+++ b/glab-repo/references/commands.md
@@ -12,26 +12,26 @@
             
   COMMANDS  
             
-    archive [<repo>] [<dir>] [--flags]                                                                 Get an archive of the repository.
-    clone <repo>               [<dir>] [-- <gitflags>...] [<dir>] [-- <gitflags>...] [--flags]  Clone a GitLab repository or project.
-    glab repo clone -g <group>                                                                                                       
-    contributors [--flags]                                                                      Get repository contributors list.
-    create [path] [--flags]                                                                     Create a new GitLab project/repository.
-    delete [[<NAMESPACE>/]<NAME>] [--flags]                                                      Delete an existing project on GitLab.
-    fork [<repo>] [--flags]                                                                       Fork a GitLab repository.
-    list [--flags]                                                                              Get list of repositories.
-    members <command> [command] [--flags]                                                       Manage project members.
-    mirror [ID | URL | PATH] [--flags]                                                          Configure mirroring on an existing project to sync with a remote repository.
-    publish <command> [command] [--flags]                                                       Publishes resources in the project.
-    remote <subcommand>                                                                          Manage Git remotes for a GitLab project.
-    search [--flags]                                                                            Search for GitLab repositories and projects by name.
-    transfer [repo] [--flags]                                                                   Transfer a repository to a new namespace.
-    update [path] [--flags]                                                                     Update an existing GitLab project or repository.
-    view [repository] [--flags]                                                                 View a project or repository.
+    archive [<repo>] [<dir>] [--flags]                                 Get an archive of the repository.
+    clone [<repo> | -g <group>] [<dir>]  [-- <gitflags>...] [--flags]  Clone a GitLab repository or project.
+    contributors [--flags]                                             Get repository contributors list.
+    create [path] [--flags]                                            Create a new GitLab project/repository.
+    delete [[<NAMESPACE>/]<NAME>] [--flags]                            Delete an existing project on GitLab.
+    fork [<repo>] [--flags]                                            Fork a GitLab repository.
+    list [--flags]                                                     Get list of repositories.
+    members <command> [command] [--flags]                              Manage project members.
+    mirror [<id | url | path>] [--flags]                               Configure mirroring on an existing project to sync with a remote repository.
+    prune [--flags]                                                    Delete local Git branches whose merge request has been merged.
+    publish <command> [command] [--flags]                              Publishes resources in the project.
+    remote <subcommand> [command]                                      Manage Git remotes for a GitLab project.
+    search [--flags]                                                   Search for GitLab repositories and projects by name.
+    transfer [repo] [--flags]                                          Transfer a repository to a new namespace.
+    update [path] [--flags]                                            Update an existing GitLab project or repository.
+    view [repository] [--flags]                                        View a project or repository.
          
   FLAGS  
          
-    -h --help                                                                                   Show help for this command.
+    -h --help                                                          Show help for this command.
 ```
 
 ## repo archive
@@ -50,6 +50,7 @@
   USAGE
 
     glab repo archive [<repo>] [<dir>] [--flags]
+
   EXAMPLES  
             
     $ glab repo archive profclems/glab                        
@@ -144,26 +145,26 @@
             
   COMMANDS  
             
-    archive [<repo>] [<dir>] [--flags]                                                                 Get an archive of the repository.
-    clone <repo>               [<dir>] [-- <gitflags>...] [<dir>] [-- <gitflags>...] [--flags]  Clone a GitLab repository or project.
-    glab repo clone -g <group>                                                                                                       
-    contributors [--flags]                                                                      Get repository contributors list.
-    create [path] [--flags]                                                                     Create a new GitLab project/repository.
-    delete [[<NAMESPACE>/]<NAME>] [--flags]                                                      Delete an existing project on GitLab.
-    fork [<repo>] [--flags]                                                                       Fork a GitLab repository.
-    list [--flags]                                                                              Get list of repositories.
-    members <command> [command] [--flags]                                                       Manage project members.
-    mirror [ID | URL | PATH] [--flags]                                                          Configure mirroring on an existing project to sync with a remote repository.
-    publish <command> [command] [--flags]                                                       Publishes resources in the project.
-    remote <subcommand>                                                                          Manage Git remotes for a GitLab project.
-    search [--flags]                                                                            Search for GitLab repositories and projects by name.
-    transfer [repo] [--flags]                                                                   Transfer a repository to a new namespace.
-    update [path] [--flags]                                                                     Update an existing GitLab project or repository.
-    view [repository] [--flags]                                                                 View a project or repository.
+    archive [<repo>] [<dir>] [--flags]                                 Get an archive of the repository.
+    clone [<repo> | -g <group>] [<dir>]  [-- <gitflags>...] [--flags]  Clone a GitLab repository or project.
+    contributors [--flags]                                             Get repository contributors list.
+    create [path] [--flags]                                            Create a new GitLab project/repository.
+    delete [[<NAMESPACE>/]<NAME>] [--flags]                            Delete an existing project on GitLab.
+    fork [<repo>] [--flags]                                            Fork a GitLab repository.
+    list [--flags]                                                     Get list of repositories.
+    members <command> [command] [--flags]                              Manage project members.
+    mirror [<id | url | path>] [--flags]                               Configure mirroring on an existing project to sync with a remote repository.
+    prune [--flags]                                                    Delete local Git branches whose merge request has been merged.
+    publish <command> [command] [--flags]                              Publishes resources in the project.
+    remote <subcommand> [command]                                      Manage Git remotes for a GitLab project.
+    search [--flags]                                                   Search for GitLab repositories and projects by name.
+    transfer [repo] [--flags]                                          Transfer a repository to a new namespace.
+    update [path] [--flags]                                            Update an existing GitLab project or repository.
+    view [repository] [--flags]                                        View a project or repository.
          
   FLAGS  
          
-    -h --help                                                                                   Show help for this command.
+    -h --help                                                          Show help for this command.
 ```
 
 ## repo contributors

--- a/glab-repo/references/commands.md
+++ b/glab-repo/references/commands.md
@@ -12,13 +12,13 @@
             
   COMMANDS  
             
-    archive <command> [--flags]                                                                 Get an archive of the repository.
+    archive [<repo>] [<dir>] [--flags]                                                                 Get an archive of the repository.
     clone <repo>               [<dir>] [-- <gitflags>...] [<dir>] [-- <gitflags>...] [--flags]  Clone a GitLab repository or project.
     glab repo clone -g <group>                                                                                                       
     contributors [--flags]                                                                      Get repository contributors list.
     create [path] [--flags]                                                                     Create a new GitLab project/repository.
-    delete <NAME> [<NAMESPACE>/] [--flags]                                                      Delete an existing project on GitLab.
-    fork <repo> [--flags]                                                                       Fork a GitLab repository.
+    delete [[<NAMESPACE>/]<NAME>] [--flags]                                                      Delete an existing project on GitLab.
+    fork [<repo>] [--flags]                                                                       Fork a GitLab repository.
     list [--flags]                                                                              Get list of repositories.
     members <command> [command] [--flags]                                                       Manage project members.
     mirror [ID | URL | PATH] [--flags]                                                          Configure mirroring on an existing project to sync with a remote repository.
@@ -38,17 +38,18 @@
 
 ```
 
-  Clone supports these shorthand references:                                                                            
+  Without a repository argument, archives the current repository.
+  The repository accepts these shorthand references:
                                                                                                                         
   - repo                                                                                                                
   - namespace/repo                                                                                                      
   - namespace/group/repo                                                                                                
                                                                                                                         
-         
-  USAGE  
-         
-    glab repo archive <command> [--flags]                     
-            
+  The second argument sets the directory to download the archive into.
+
+  USAGE
+
+    glab repo archive [<repo>] [<dir>] [--flags]
   EXAMPLES  
             
     $ glab repo archive profclems/glab                        
@@ -143,13 +144,13 @@
             
   COMMANDS  
             
-    archive <command> [--flags]                                                                 Get an archive of the repository.
+    archive [<repo>] [<dir>] [--flags]                                                                 Get an archive of the repository.
     clone <repo>               [<dir>] [-- <gitflags>...] [<dir>] [-- <gitflags>...] [--flags]  Clone a GitLab repository or project.
     glab repo clone -g <group>                                                                                                       
     contributors [--flags]                                                                      Get repository contributors list.
     create [path] [--flags]                                                                     Create a new GitLab project/repository.
-    delete <NAME> [<NAMESPACE>/] [--flags]                                                      Delete an existing project on GitLab.
-    fork <repo> [--flags]                                                                       Fork a GitLab repository.
+    delete [[<NAMESPACE>/]<NAME>] [--flags]                                                      Delete an existing project on GitLab.
+    fork [<repo>] [--flags]                                                                       Fork a GitLab repository.
     list [--flags]                                                                              Get list of repositories.
     members <command> [command] [--flags]                                                       Manage project members.
     mirror [ID | URL | PATH] [--flags]                                                          Configure mirroring on an existing project to sync with a remote repository.
@@ -249,6 +250,8 @@
 
   Delete an existing project on GitLab.                                                                                 
                                                                                                                         
+  Without an argument, targets the project for the current repository.
+
   This permanently deletes the entire project, including:                                                               
                                                                                                                         
   - The Git repository.                                                                                                 
@@ -262,7 +265,7 @@
          
   USAGE  
          
-    glab repo delete <NAME> [<NAMESPACE>/] [--flags]          
+    glab repo delete [[<NAMESPACE>/]<NAME>] [--flags]
             
   EXAMPLES  
             
@@ -288,7 +291,7 @@
          
   USAGE  
          
-    glab repo fork <repo> [--flags]          
+    glab repo fork [<repo>] [--flags]
             
   EXAMPLES  
             

--- a/glab-schedule/SKILL.md
+++ b/glab-schedule/SKILL.md
@@ -39,6 +39,10 @@ glab schedule list --output json
 glab schedule list -F json
 ```
 
+## Schedule variables
+
+Schedule variable keys are validated before schedule creation. Empty keys are rejected, so check generated `--variable <key>:<value>` input before creating schedules.
+
 ## Subcommands
 
 See [references/commands.md](references/commands.md) for full `--help` output.

--- a/glab-securefile/SKILL.md
+++ b/glab-securefile/SKILL.md
@@ -69,6 +69,8 @@ glab securefile remove --name signing-certificate.p12 --yes
 
 Deletion is permanent. In non-interactive environments, `--yes` / `-y` is required. Resolve and verify the intended project with `-R/--repo` before deleting, and prefer an ID when duplicate or ambiguous naming is possible.
 
+Choose exactly one selector for removal: a positional ID, `--id`, or `--name`. Combining selectors is a hard error, so resolve the intended file first and pass only the one selector you want to use.
+
 ## Updating secure files
 
 Update a secure file by its exact stored name and a local replacement path. The command asks for confirmation unless `--yes` / `-y` is set; `overwrite` is an alias.

--- a/glab-securefile/SKILL.md
+++ b/glab-securefile/SKILL.md
@@ -42,6 +42,17 @@ glab securefile --help
 
 `glab securefile get` requires GitLab 18.0 or later. On older GitLab instances, list or download by ID/name instead of expecting the details endpoint to work.
 
+## Downloading secure files
+
+Use `--all` to download every secure file across all API pages; it is not limited to the first 100 results. Keep checksum verification enabled unless the user explicitly accepts the risk of `--no-verify` or `--force-download`.
+
+```bash
+# Download every secure file to a controlled directory
+glab securefile download --all --output-dir ./secure-files -R group/project
+```
+
+Treat the destination as sensitive, keep it outside version control, and verify the target project before downloading.
+
 ## Removing secure files
 
 Secure-file deletion accepts a positional numeric ID, `--id`, or an exact file name via `--name`:

--- a/glab-securefile/references/commands.md
+++ b/glab-securefile/references/commands.md
@@ -73,7 +73,7 @@
 
   To download a single file, identify it by its numeric ID (as a positional
   argument or with `--id`) or by its name with `--name`. To download every
-  secure file in the project (up to a limit of 100), use `--all`.
+  secure file in the project, use `--all`.
 
   Use `--path` to save a single download to a specific filename, or
   `--output-dir` to choose the destination directory when downloading
@@ -110,7 +110,7 @@
     # Download without verifying the checksum
     glab securefile download 1 --no-verify
 
-    # Download all secure files in the project (up to 100)
+    # Download all secure files in the project
     glab securefile download --all
 
     # Download all secure files to a specific directory
@@ -118,7 +118,7 @@
 
   FLAGS
 
-    --all             Download all (limit 100) of a project's secure files. Files are downloaded with their original name and file extension.
+    --all             Download all of a project's secure files. Files are downloaded with their original name and file extension.
     --force-download  Force download file(s) even if checksum verification fails. Warning: when enabled, this setting allows the download of files that are corrupt or tampered with.
     -h --help         Show help for this command.
     --id              Id of the secure file to download.

--- a/glab-ssh-key/SKILL.md
+++ b/glab-ssh-key/SKILL.md
@@ -13,13 +13,13 @@ description: Manage SSH keys for GitLab account including add, list, and delete 
   USAGE
     glab ssh-key <command> [command] [--flags]
   COMMANDS
-    add [key-file] [--flags]   Add an SSH key to your GitLab account.
-    delete <key-id> [--flags]  Deletes a single SSH key specified by the ID.
-    get <key-id> [--flags]     Returns a single SSH key specified by the ID.
-    list [--flags]             Get a list of SSH keys for the currently authenticated user.
+    add [key-file] [--flags]     Add an SSH key to your GitLab account.
+    delete [<key-id>] [--flags]  Deletes a single SSH key specified by the ID.
+    get [<key-id>] [--flags]     Returns a single SSH key specified by the ID.
+    list [--flags]               Get a list of SSH keys for the currently authenticated user.
   FLAGS
-    -h --help                  Show help for this command.
-    -R --repo                  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -h --help                    Show help for this command.
+    -R --repo                    Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
 ```
 
 ## ⚠️ Security Warning: Public Keys Only

--- a/glab-ssh-key/references/commands.md
+++ b/glab-ssh-key/references/commands.md
@@ -12,15 +12,15 @@
             
   COMMANDS  
             
-    add [key-file] [--flags]   Add an SSH key to your GitLab account.
-    delete <key-id> [--flags]  Deletes a single SSH key specified by the ID.
-    get <key-id> [--flags]     Returns a single SSH key specified by the ID.
-    list [--flags]             Get a list of SSH keys for the currently authenticated user.
+    add [key-file] [--flags]     Add an SSH key to your GitLab account.
+    delete [<key-id>] [--flags]  Deletes a single SSH key specified by the ID.
+    get [<key-id>] [--flags]     Returns a single SSH key specified by the ID.
+    list [--flags]               Get a list of SSH keys for the currently authenticated user.
          
   FLAGS  
          
-    -h --help                  Show help for this command.
-    -R --repo                  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -h --help                    Show help for this command.
+    -R --repo                    Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
 ```
 
 ## ssh-key add

--- a/glab-ssh-key/references/commands.md
+++ b/glab-ssh-key/references/commands.md
@@ -61,7 +61,7 @@
          
   USAGE  
          
-    glab ssh-key delete <key-id> [--flags]  
+    glab ssh-key delete [<key-id>] [--flags]
             
   EXAMPLES  
             
@@ -90,7 +90,7 @@
          
   USAGE  
          
-    glab ssh-key get <key-id> [--flags]  
+    glab ssh-key get [<key-id>] [--flags]
             
   EXAMPLES  
             

--- a/glab-variable/references/commands.md
+++ b/glab-variable/references/commands.md
@@ -246,7 +246,7 @@
     $ glab variable update FROM_ENV_WITH_FLAG -v"${ENV_VAR}"
     $ glab variable update FROM_FILE < secret.txt
     $ cat file.txt | glab variable update SERVER_TOKEN
-    $ cat token.txt | glab variable update GROUP_TOKEN -g mygroup
+    $ cat token.txt | glab variable update GROUP_TOKEN -g mygroup             
 
   FLAGS
 

--- a/glab-variable/references/commands.md
+++ b/glab-variable/references/commands.md
@@ -246,7 +246,7 @@
     $ glab variable update FROM_ENV_WITH_FLAG -v"${ENV_VAR}"
     $ glab variable update FROM_FILE < secret.txt
     $ cat file.txt | glab variable update SERVER_TOKEN
-    $ cat token.txt | glab variable update GROUP_TOKEN -g mygroup --scope=prod
+    $ cat token.txt | glab variable update GROUP_TOKEN -g mygroup
 
   FLAGS
 


### PR DESCRIPTION
## Upstream

- GitLab CLI `glab` **v1.110.0**
- Canonical release: https://gitlab.com/gitlab-org/cli/-/releases/v1.110.0
- Compared against the previously processed v1.109.0 release.

## Upstream CLI changes reviewed

- Non-interactive `glab auth login` now persists explicit Git/API protocol choices.
- `glab api` fixes preserve NDJSON number precision and encode empty-array fields correctly.
- CI behavior now rejects failed remote-lint responses and empty variable keys, and tracing stops for canceled jobs.
- `glab securefile download --all` now paginates beyond the former 100-file limit.
- Generated help now correctly marks optional release, repository, and SSH-key arguments; the alias placeholder and group-variable examples were corrected.
- The dependency-firewall MITM proxy/classifier remains internal in the v1.110.0 release binary: `glab df` is not exposed, so no standalone skill was added.

## Skill/package changes

- Bumped the skill package metadata from `1.13.18` to `1.13.19`.
- Updated current operational guidance in `glab-auth`, `glab-api`, `glab-ci`, `glab-release`, and `glab-securefile`.
- Refreshed affected captured command references for alias, release, repository, secure-file, SSH-key, and variable commands.
- No scheduler, refresh engine, cron script, or GitHub Actions workflow was added.

## Validation

- Verified SHA-256 checksums for downloaded upstream macOS arm64 v1.109.0 and v1.110.0 release binaries.
- Live v1.110.0 help probe passed for all captured synopsis/example changes and confirmed `glab df` is not exposed.
- `git diff --check` passed.
- Agent Skills packaging sanity passed: 46 discoverable skills, no root `SKILL.md`, unique frontmatter names, and valid local skill links.
- `npx --yes skills add . --list` found all 46 skills.
- `bash scripts/build-claude-skill.sh --output <validation-path>/claude-skill.zip` completed with 45 sub-skills plus the top-level skill; the archive contains exactly one `SKILL.md`.

## Review request

Vince, please review the operational guidance and package version bump. This PR is intentionally not merged by Hermes.
