### PR TITLE
docs: refresh glab skills for v1.111.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,12 @@
-1.13.19
+1.13.20
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.20
+  - glab v1.111.0 refresh: documented OS-keyring-by-default authentication and `--insecure-storage`, issue-board pagination, wiki cloning, non-interactive title-only MR creation, and discussion-prefix reply targeting.
+  - Documented absolute package/secure-file download destinations, deterministic JSON error objects, nested namespace preservation during project creation, stack username/hook-output behavior, and deterministic CI job ordering on timestamp ties.
+  - Re-captured the affected auth, issue-board, repository, package, secure-file, and MR note help from the checksum-verified v1.111.0 release binary.
 - v1.13.19
   - glab v1.110.0 refresh: documented reliable all-page secure-file downloads, non-interactive auth protocol persistence, and API/CI automation correctness fixes.
   - Corrected captured help for alias positional placeholders, secure-file pagination, and the group-variable update example; re-synchronized the parent release, repository, and SSH-key command tables with official v1.110.0 help.

--- a/VERSION
+++ b/VERSION
@@ -5,8 +5,8 @@ Release/version change metadata for this skill set lives here, not in individual
 Historical notes consolidated from skill docs:
 - v1.13.20
   - glab v1.111.0 refresh: documented OS-keyring-by-default authentication and `--insecure-storage`, issue-board pagination, wiki cloning, non-interactive title-only MR creation, and discussion-prefix reply targeting.
-  - Documented absolute package/secure-file download destinations, deterministic JSON error objects, nested namespace preservation during project creation, stack username/hook-output behavior, and deterministic CI job ordering on timestamp ties.
-  - Re-captured the affected auth, issue-board, repository, package, secure-file, and MR note help from the checksum-verified v1.111.0 release binary.
+  - Documented absolute package/secure-file download destinations, deterministic JSON error objects, nested namespace preservation during project creation, stack username/hook-output behavior, and deterministic CI view/job-lookup tie-breaking on timestamp ties.
+  - Re-captured the affected auth, config, issue-board, repository, package, secure-file, and MR note help from the checksum-verified v1.111.0 release binary.
 - v1.13.19
   - glab v1.110.0 refresh: documented reliable all-page secure-file downloads, non-interactive auth protocol persistence, and API/CI automation correctness fixes.
   - Corrected captured help for alias positional placeholders, secure-file pagination, and the group-variable update example; re-synchronized the parent release, repository, and SSH-key command tables with official v1.110.0 help.

--- a/glab-api/SKILL.md
+++ b/glab-api/SKILL.md
@@ -174,6 +174,7 @@ Rules of thumb:
 - If the command has `--output` or `--output-format`, pass the JSON mode too: `--output=json` or `--output-format=json`. `--jq` fails fast if the output flag is still text.
 - Commands that always emit JSON and have no output-format flag can use `--jq` directly.
 - Use external `jq` when you need non-JSON inputs, newline-delimited JSON processing, streaming over very large outputs, or jq options not available through glab's embedded filter.
+- When a command fails under `--output=json`, glab writes a JSON error object to stdout while retaining the human-readable error on stderr and a nonzero exit status. Check the exit status first; do not mistake a parseable error object for successful data.
 
 ```bash
 # Built-in filtering on a structured-output command

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -60,7 +60,8 @@ glab auth login \
   --container-registry-domains "registry.gitlab.com,gitlab.com"
 
 # Explicitly opt out of keyring storage (stores the token as plaintext)
-glab auth login --hostname gitlab.company.com --insecure-storage
+glab auth login --hostname gitlab.company.com --insecure-storage \
+  --stdin < approved-token-file
 ```
 
 ### Credential storage

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -58,7 +58,18 @@ glab auth login \
   --hostname gitlab.com \
   --web \
   --container-registry-domains "registry.gitlab.com,gitlab.com"
+
+# Explicitly opt out of keyring storage (stores the token as plaintext)
+glab auth login --hostname gitlab.company.com --insecure-storage
 ```
+
+### Credential storage
+
+On a normal workstation, `glab auth login` stores credentials in the operating system keyring by default when one is available: macOS Keychain, Windows Credential Manager, or Linux Secret Service. The old `--use-keyring` flag is deprecated because keyring storage is now the default. Re-running login migrates a credential previously stored as plaintext in the config file into the keyring.
+
+Use `--insecure-storage` only when plaintext config-file storage is explicitly required and its risk is accepted. If no keyring backend is available, glab warns and falls back to the config file. In CI (`GITLAB_CI` or `CI` is set), glab defaults to config-file storage because keyrings are usually unavailable or ephemeral; prefer environment credentials rather than persisting a login there.
+
+If a keyring is locked, unavailable, or denies access, glab reports the credential-read failure directly. Fix keyring access or re-authenticate instead of treating the resulting error as an invalid token.
 
 When re-authenticating interactively, `glab` preserves saved per-host values such as a custom API host, SSH host, and container-registry domains unless you explicitly override them with flags or prompts. Verify these values after re-authentication instead of deleting the config preemptively:
 
@@ -186,10 +197,15 @@ If the wrong-identity write changed state beyond a comment or reply, re-auth as 
 
 **Env-token auth failures:**
 - If `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, or `OAUTH_TOKEN` is exported, it overrides stored credentials.
+- `GITLAB_TOKEN` and `GITLAB_ACCESS_TOKEN` are treated as personal access tokens independently of a stored OAuth profile, so a temporary PAT does not inherit or refresh saved OAuth state.
 - If auth suddenly fails, check whether an env token is being picked up before assuming your saved login is broken.
 - These failures can affect both read operations and writes, not just write pre-flight checks.
 - Verify the active actor and token path with `glab auth status` and `glab api user` before any GitLab write.
 - In multi-agent shells, deliberately re-source the intended env file with `set -a; source ...; set +a` before retrying.
+
+**Self-managed OAuth URL or refresh problems:**
+- Re-authenticate with the full configured host/subfolder; browser OAuth includes the configured subfolder in its authorization URL.
+- A re-authentication response that omits a replacement refresh token preserves the existing refresh token instead of clearing it.
 
 **Multiple instances:**
 - Use `--hostname` flag to specify instance

--- a/glab-auth/references/commands.md
+++ b/glab-auth/references/commands.md
@@ -9,10 +9,22 @@ Source: <https://docs.gitlab.com/cli/auth/>
 ```
 Authenticates with a GitLab instance.
 
-  Stores your credentials in the global configuration file
-  (default `~/.config/glab-cli/config.yml`).
-  To store your token in your operating system's keyring instead, use `--use-keyring`.
-  After authentication, all `glab` commands use the stored credentials.
+  By default, glab stores your credentials in your operating system's
+  keyring (macOS Keychain, Windows Credential Manager, or the Secret
+  Service on Linux) when one is available. If no keyring is available,
+  or if you pass `--insecure-storage`, glab stores them in the global
+  configuration file (default `~/.config/glab-cli/config.yml`) as
+  plaintext instead. After authentication, all `glab` commands use the
+  stored credentials.
+
+  If you previously signed in and your credentials are stored as
+  plaintext in the configuration file, run `glab auth login` again to
+  move them into the keyring.
+
+  In CI (when `GITLAB_CI` or `CI` is set), glab stores credentials in the
+  configuration file rather than the keyring. Credentials in CI are
+  usually supplied through environment variables, and an OS keyring is
+  often unavailable there.
 
   If `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, or `OAUTH_TOKEN` are set,
   they take precedence over the stored credentials.
@@ -60,11 +72,11 @@ Authenticates with a GitLab instance.
     -g --git-protocol             Git protocol: ssh, https, http
     -h --help                     Show help for this command.
     --hostname                    The hostname of the GitLab instance to authenticate with.
+    --insecure-storage            Store the token as plaintext in the configuration file instead of the operating system's keyring.
     -j --job-token                Ci job token.
     --ssh-hostname                Ssh hostname for instances with a different SSH endpoint.
     --stdin                       Read token from standard input.
     -t --token                    Your GitLab access token.
-    --use-keyring                 Store token in your operating system's keyring.
     --web                         Skip the login type prompt and use web/OAuth login.
 ```
 

--- a/glab-auth/references/commands.md
+++ b/glab-auth/references/commands.md
@@ -14,7 +14,7 @@ Authenticates with a GitLab instance.
   Service on Linux) when one is available. If no keyring is available,
   or if you pass `--insecure-storage`, glab stores them in the global
   configuration file (default `~/.config/glab-cli/config.yml`) as
-  plaintext instead. After authentication, all `glab` commands use the
+  plaintext instead. After authentication, all glab commands use the
   stored credentials.
 
   If you previously signed in and your credentials are stored as
@@ -27,14 +27,13 @@ Authenticates with a GitLab instance.
   often unavailable there.
 
   If `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, or `OAUTH_TOKEN` are set,
-  they take precedence over the stored credentials.
-  When CI auto-login is enabled, these variables also override `CI_JOB_TOKEN`.
+  they take precedence over the stored credentials. When CI auto-login is
+  enabled, these variables also override `CI_JOB_TOKEN`.
 
   To pass a token on standard input, use `--stdin`.
 
-  In interactive mode, `glab` detects GitLab instances from your Git remotes
+  In interactive mode, glab detects GitLab instances from your Git remotes
   and lists them as options, so you do not have to type the hostname manually.
-
 
   USAGE
 
@@ -43,7 +42,7 @@ Authenticates with a GitLab instance.
   EXAMPLES
 
     # Start interactive setup
-    # (If in a Git repository, glab will detect and suggest GitLab instances from remotes)
+    # If in a Git repository, glab detects and suggests GitLab instances from remotes
     glab auth login
 
     # Authenticate against `gitlab.com` by reading the token from a file
@@ -53,29 +52,38 @@ Authenticates with a GitLab instance.
     glab auth login --hostname salsa.debian.org
 
     # Non-interactive setup
-    glab auth login --hostname gitlab.example.org --token glpat-xxx --api-host gitlab.example.org:3443 --api-protoc…
+    glab auth login --hostname gitlab.example.org --token glpat-xxx --api-host gitlab.example.org:3443 --api-protocol https --git-protocol ssh
 
-    # Non-interactive setup reading token from a file
-    glab auth login --hostname gitlab.example.org --api-host gitlab.example.org:3443 --api-protocol https --git-pro…
+    # Non-interactive setup reading the token from a file
+    glab auth login --hostname gitlab.example.org --api-host gitlab.example.org:3443 --api-protocol https --git-protocol ssh --stdin < myaccesstoken.txt
 
     # Semi-interactive OAuth login, skipping all prompts except browser auth
-    glab auth login --hostname gitlab.com --web --git-protocol ssh --container-registry-domains "gitlab.com,gitlab.…
+    glab auth login --hostname gitlab.com --web --git-protocol ssh --container-registry-domains "gitlab.com,gitlab.com:443,registry.gitlab.com"
 
-    # Non-interactive CI/CD setup
-    glab auth login --hostname $CI_SERVER_HOST --job-token $CI_JOB_TOKEN
+    # OAuth device authorization flow for headless environments without a local browser.
+    # glab displays a one-time code and verification URL; authorize on any other device
+    # with a browser. Requires GitLab 17.9 or later.
+    glab auth login --hostname gitlab.com --device
+
+    # CI/CD setup: for most cases, prefer auto-login over manual login
+    GLAB_ENABLE_CI_AUTOLOGIN=true glab release list -R $CI_PROJECT_PATH
+
+    # CI/CD setup with manual login when a command does not support CI job tokens
+    glab auth login --hostname $CI_SERVER_FQDN --job-token $CI_JOB_TOKEN --api-protocol $CI_SERVER_PROTOCOL
 
   FLAGS
 
-    -a --api-host                 Api host url.
-    -p --api-protocol             Api protocol: https, http
-    --container-registry-domains  Container registry and image dependency proxy domains (comma-separated).
-    -g --git-protocol             Git protocol: ssh, https, http
+    -a --api-host                 Hostname for the API endpoint, if different from --hostname. Accepts a hostname or hostname:port. Use only when the API is served from a different host than the Git remote.
+    -p --api-protocol             API protocol. Options: https, http.
+    --container-registry-domains  Container registry and image dependency proxy domains, comma-separated.
+    --device                      Use the OAuth 2.0 device authorization flow. Useful for headless environments where a local browser is not available. Requires GitLab 17.9 or later.
+    -g --git-protocol             Git protocol. Options: ssh, https, http.
     -h --help                     Show help for this command.
     --hostname                    The hostname of the GitLab instance to authenticate with.
     --insecure-storage            Store the token as plaintext in the configuration file instead of the operating system's keyring.
-    -j --job-token                Ci job token.
-    --ssh-hostname                Ssh hostname for instances with a different SSH endpoint.
-    --stdin                       Read token from standard input.
+    -j --job-token                CI job token.
+    --ssh-hostname                SSH hostname for instances with a different SSH endpoint. A port is not required; Git uses the port from the remote URL.
+    --stdin                       Read the token from standard input.
     -t --token                    Your GitLab access token.
     --web                         Skip the login type prompt and use web/OAuth login.
 ```

--- a/glab-auth/references/commands.md
+++ b/glab-auth/references/commands.md
@@ -74,15 +74,15 @@ Authenticates with a GitLab instance.
   FLAGS
 
     -a --api-host                 Hostname for the API endpoint, if different from --hostname. Accepts a hostname or hostname:port. Use only when the API is served from a different host than the Git remote.
-    -p --api-protocol             API protocol. Options: https, http.
+    -p --api-protocol             Api protocol. Options: https, http.
     --container-registry-domains  Container registry and image dependency proxy domains, comma-separated.
     --device                      Use the OAuth 2.0 device authorization flow. Useful for headless environments where a local browser is not available. Requires GitLab 17.9 or later.
     -g --git-protocol             Git protocol. Options: ssh, https, http.
     -h --help                     Show help for this command.
     --hostname                    The hostname of the GitLab instance to authenticate with.
     --insecure-storage            Store the token as plaintext in the configuration file instead of the operating system's keyring.
-    -j --job-token                CI job token.
-    --ssh-hostname                SSH hostname for instances with a different SSH endpoint. A port is not required; Git uses the port from the remote URL.
+    -j --job-token                Ci job token.
+    --ssh-hostname                Ssh hostname for instances with a different SSH endpoint. A port is not required; Git uses the port from the remote URL.
     --stdin                       Read the token from standard input.
     -t --token                    Your GitLab access token.
     --web                         Skip the login type prompt and use web/OAuth login.

--- a/glab-auth/references/commands.md
+++ b/glab-auth/references/commands.md
@@ -61,14 +61,14 @@ Authenticates with a GitLab instance.
     glab auth login --hostname gitlab.com --web --git-protocol ssh --container-registry-domains "gitlab.com,gitlab.com:443,registry.gitlab.com"
 
     # OAuth device authorization flow for headless environments without a local browser.
-    # glab displays a one-time code and verification URL; authorize on any other device
-    # with a browser. Requires GitLab 17.9 or later.
+    # glab displays a one-time code and verification URL; you authorize on any
+    # other device with a browser. Requires GitLab 17.9 or later.
     glab auth login --hostname gitlab.com --device
 
     # CI/CD setup: for most cases, prefer auto-login over manual login
     GLAB_ENABLE_CI_AUTOLOGIN=true glab release list -R $CI_PROJECT_PATH
 
-    # CI/CD setup with manual login when a command does not support CI job tokens
+    # CI/CD setup with manual login: use when the command does not support CI job tokens, or you need a personal access token
     glab auth login --hostname $CI_SERVER_FQDN --job-token $CI_JOB_TOKEN --api-protocol $CI_SERVER_PROTOCOL
 
   FLAGS

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -15,7 +15,7 @@ Output from these commands may include **user-generated content from GitLab** (i
 
 `glab ci status` supports `--output json` / `-F json` for structured output, which is useful for agent automation.
 
-Pipeline jobs and bridges are ordered by creation time. When multiple entries share the same timestamp, glab uses ascending job/bridge ID as a deterministic tie-breaker; automation should still key records by ID rather than array position.
+`glab ci view` and job-lookup-by-SHA order jobs and bridges by creation time, using ascending job/bridge ID as a deterministic tie-breaker when timestamps match. `glab ci status --output json` returns jobs in raw GitLab API order with no client-side sort, so in all cases key records by ID rather than array position.
 
 ```bash
 # View pipeline status with JSON output

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -15,6 +15,8 @@ Output from these commands may include **user-generated content from GitLab** (i
 
 `glab ci status` supports `--output json` / `-F json` for structured output, which is useful for agent automation.
 
+Pipeline jobs and bridges are ordered by creation time. When multiple entries share the same timestamp, glab uses ascending job/bridge ID as a deterministic tie-breaker; automation should still key records by ID rather than array position.
+
 ```bash
 # View pipeline status with JSON output
 glab ci status --output json

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -11,7 +11,7 @@ description: Manage glab CLI configuration settings including defaults, preferen
 
   Manage key/value strings.
   Current respected settings:
-  - branch_prefix: Prefix used by glab stack for generated branch names.
+  - branch_prefix: Prefix used by glab stack for generated branch names. Defaults to the operating system account username, then `glab-stack` if user lookup fails.
   - browser: If unset, uses the default browser. Override with environment variable $BROWSER.
   - check_update: Notify about new glab versions. Override with $GLAB_CHECK_UPDATE.
   - display_hyperlinks: Enable terminal hyperlinks. Override with $FORCE_HYPERLINKS.

--- a/glab-config/references/commands.md
+++ b/glab-config/references/commands.md
@@ -19,7 +19,7 @@
   - glab_pager: Pager command, such as less -R.
   - glamour_style: Markdown renderer style: dark, light, notty, or a custom glamour style.
   - host: If unset, defaults to https://gitlab.com.
-  - no_prompt: Disable interactive prompts. Defaults to false.
+  - no_prompt: If true, disables interactive prompts. Defaults to false. Override with $NO_PROMPT.
   - notify_skill_updates: Show installed agent-skill update notices. Defaults to true. Override with $GLAB_NOTIFY_SKILL_UPDATES.
   - orbit_local_auto_download: Automatically download Orbit local CLI without prompting.
   - orbit_local_auto_run: Automatically run Orbit local CLI without prompting.

--- a/glab-config/references/commands.md
+++ b/glab-config/references/commands.md
@@ -8,7 +8,7 @@
                                                                                                                         
   Current respected settings:                                                                                           
                                                                                                                         
-  - branch_prefix: Prefix used by glab stack when naming generated branches. Defaults to $USER, then glab-stack.
+  - branch_prefix: Prefix used by glab stack when naming generated branches. Defaults to the current user's username (from os/user.Current), then glab-stack if unavailable.
   - browser: If unset, uses the default browser. Override with $BROWSER.
   - check_update: Notify about new glab versions. Defaults to true. Override with $GLAB_CHECK_UPDATE.
   - display_hyperlinks: Enable terminal hyperlinks. Defaults to true. Override with $FORCE_HYPERLINKS.

--- a/glab-issue/SKILL.md
+++ b/glab-issue/SKILL.md
@@ -117,7 +117,12 @@ glab issue update 456 --milestone "Sprint 23"
 **Board view:**
 ```bash
 glab issue board view
+
+# Retrieve every project/group board issue instead of only the first API page
+glab issue board view --paginate
 ```
+
+Use `--paginate` for complete board triage when a board can exceed one API page. Without it, the interactive board uses the first page returned by GitLab. The option works for both project and group board issue retrieval and can be combined with `--assignee`, `--labels`, or `--milestone` filters.
 
 ### Linking issues to work
 

--- a/glab-issue/references/commands.md
+++ b/glab-issue/references/commands.md
@@ -58,6 +58,26 @@
     -R --repo         Select another repository using the OWNER/REPO format or the project ID. Supports group namespaces.
 ```
 
+## issue board view
+
+```
+Opens an interactive view of the project's issue boards in your terminal, where you can browse issues by list.
+
+USAGE
+  glab issue board view [--flags]
+
+EXAMPLES
+  glab issue board view
+
+FLAGS
+  -a --assignee   Filter board issues by assignee username.
+  -h --help       Show help for this command.
+  -l --labels     Filter board issues by labels. Multiple labels can be comma-separated or specified by repeating the flag.
+  -m --milestone  Filter board issues by milestone.
+     --paginate   Make additional HTTP requests to retrieve all board issues.
+  -R --repo       Select another repository using the OWNER/REPO format or the project ID. Supports group namespaces.
+```
+
 ## issue close
 
 ```

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -40,6 +40,16 @@ glab mr create --fill --auto-merge
 glab mr create --fill --template .gitlab/merge_request_templates/default.md
 ```
 
+In a non-interactive environment, an explicit `--title` is sufficient; glab can create the MR with an empty description instead of requiring a TTY or `--description`. Interactive terminals still prompt for a missing description/template. For deterministic automation, pass `--yes` plus any source/target/repository selectors explicitly.
+
+```bash
+GLAB_NO_PROMPT=1 glab mr create \
+  --title "Fix login timeout" \
+  --source-branch fix/login-timeout \
+  --target-branch main \
+  --yes
+```
+
 **From issue:**
 ```bash
 glab mr for 456  # Creates MR linked to issue #456
@@ -161,7 +171,7 @@ glab mr merge 123
 
 ## Listing and targeting MR discussions
 
-`glab mr note list` text output includes each note ID and discussion ID, plus both relative and absolute timestamps. Use those identifiers with `resolve`, `reopen`, or `--reply` rather than scraping author/body text.
+`glab mr note list` text output includes each note ID and an eight-character discussion ID prefix for every non-system discussion, plus both relative and absolute timestamps. Pass the characters before the ellipsis directly to `--reply`; use JSON when a workflow needs the full discussion ID. Use verified identifiers with `resolve`, `reopen`, or `--reply` rather than scraping author/body text.
 
 ```bash
 # Filter the text view
@@ -171,6 +181,9 @@ glab mr note list 123 --file src/app.ts
 # Prefer JSON when an automation needs stable IDs
 glab mr note list 123 --output json \
   --jq '.[] | {discussion_id: .id, note_ids: [.notes[].id]}'
+
+# Extract full discussion IDs
+glab mr note list 123 -F json --jq '.[].id'
 
 # Act on the verified identifier
 glab mr note resolve <discussion-or-note-id> 123

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -190,6 +190,8 @@ glab mr note resolve <discussion-or-note-id> 123
 glab mr note reopen <discussion-or-note-id> 123
 ```
 
+Upstream's generated help demonstrates the same extraction with an external `jq` pipe. This skill set prefers the supported built-in `--jq` flag so filtering stays inside `glab` and avoids a separate shell process.
+
 `--type` accepts `all`, `general`, `diff`, or `system`; `--state` accepts `all`, `resolved`, or `unresolved`; `--file` limits results to diff notes on one path. These subcommands remain experimental, so confirm live help when scripting across mixed `glab` versions.
 
 ## Native MR note flow (`glab mr note create`)

--- a/glab-mr/references/commands.md
+++ b/glab-mr/references/commands.md
@@ -470,10 +470,13 @@ Command "for" is deprecated, use `glab mr create --related-issue <issueID>`
 
 ```
 Fetches and displays merge request discussions.
-Uses the same output format as glab mr view --comments.
+Human-readable output shows an eight-character prefix for each non-system
+discussion. Use the characters before the ellipsis with
+`glab mr note create --reply`. JSON output preserves the full discussion ID in
+the `id` field of each discussion object. Extract it with:
+`glab mr note list -F json | jq -r '.[].id'`.
 Supports filtering by note type, resolution state, and file path.
-Supports JSON output for scripting. Text output includes note and discussion IDs
-and shows absolute time alongside relative time.
+Supports JSON output for scripting.
 
 USAGE
   glab mr note list [<id> | <branch>] [flags]
@@ -492,7 +495,7 @@ EXAMPLES
   glab mr note list --file src/main.go
 
   # JSON output for scripting
-  glab mr note list -F json --jq '.[].notes[].body'
+  glab mr note list -F json | jq '.[].notes[].body'
 
   # List discussions on MR 123
   glab mr note list 123

--- a/glab-packages/SKILL.md
+++ b/glab-packages/SKILL.md
@@ -88,6 +88,9 @@ glab packages download -n my-package --version 1.0.0 --filename app.zip --path .
 # Download to an exact path, renaming the file
 glab packages download -n my-package --version 1.0.0 --filename app.zip --path ./downloads/renamed.zip
 
+# Download to an absolute path (missing parent directories are created)
+glab packages download -n my-package --version 1.0.0 --filename app.zip --path /tmp/downloads/app.zip
+
 # Skip checksum verification only when you intentionally accept the integrity risk
 glab packages download -n my-package --version 1.0.0 --filename app.zip --no-verify
 
@@ -95,7 +98,7 @@ glab packages download -n my-package --version 1.0.0 --filename app.zip --no-ver
 glab packages dl -n my-package --version 1.0.0 --filename app.zip --force -R owner/repo
 ```
 
-Download is limited to **generic** package files and requires `--name`, `--version`, and `--filename`. By default glab verifies the downloaded file against registry checksum metadata and fails if the destination already exists. Use `--path` for a directory or exact output filename, `--force` to overwrite, and `--no-verify` only when checksum verification is intentionally bypassed.
+Download is limited to **generic** package files and requires `--name`, `--version`, and `--filename`. By default glab verifies the downloaded file against registry checksum metadata and fails if the destination already exists. Use `--path` for a relative or absolute directory/exact output filename; glab creates missing parent directories. Use `--force` to overwrite and `--no-verify` only when checksum verification is intentionally bypassed.
 
 ## Delete packages
 

--- a/glab-packages/references/commands.md
+++ b/glab-packages/references/commands.md
@@ -1,6 +1,6 @@
 # glab packages help
 
-> Command reference captured from upstream generated documentation and release help.
+> Command reference captured from upstream glab v1.111.0 generated documentation and release help.
 
 ## packages delete
 

--- a/glab-packages/references/commands.md
+++ b/glab-packages/references/commands.md
@@ -1,6 +1,6 @@
 # glab packages help
 
-> Command reference captured from upstream glab v1.106.0 generated documentation.
+> Command reference captured from upstream generated documentation and release help.
 
 ## packages delete
 
@@ -59,6 +59,9 @@ glab packages download -n my-package --version 1.0.0 --filename app.zip --path .
 
 # Download to an exact path, renaming the file
 glab packages download -n my-package --version 1.0.0 --filename app.zip --path ./downloads/renamed.zip
+
+# Download to an absolute path
+glab packages download -n my-package --version 1.0.0 --filename app.zip --path /tmp/downloads/app.zip
 
 # Download without verifying the checksum
 glab packages download -n my-package --version 1.0.0 --filename app.zip --no-verify

--- a/glab-repo/SKILL.md
+++ b/glab-repo/SKILL.md
@@ -13,6 +13,9 @@ Work with GitLab repositories and projects.
 # Clone a repository
 glab repo clone group/project
 
+# Clone the project's wiki repository
+glab repo clone --wiki group/project
+
 # Create new repository
 glab repo create my-new-project --public
 
@@ -51,11 +54,21 @@ glab repo search "keyword"
 
    **Note:** `glab repo create --readme` clones the newly created repository instead of using `git init`, ensuring a clean local copy with the initial README.
 
+   A path containing nested groups preserves the complete namespace. For example, `glab repo create group/subgroup/my-project` creates `my-project` under `group/subgroup`, not only the final subgroup.
+
 2. **Clone locally (if not using --readme):**
    ```bash
    glab repo clone my-username/my-project
    cd my-project
    ```
+
+   To clone only the GitLab wiki, pass `--wiki` with one project reference. It cannot be combined with group-wide `--group` cloning, and it fails clearly when the project's wiki is disabled.
+
+   ```bash
+   glab repo clone --wiki group/project
+   ```
+
+   SSH configurations that map `gitlab.com` to the official `altssh.gitlab.com` endpoint are recognized as GitLab.com rather than as a separate self-managed host.
 
 3. **Initialize with content:**
    ```bash

--- a/glab-repo/references/commands.md
+++ b/glab-repo/references/commands.md
@@ -94,41 +94,41 @@
   EXAMPLES
 
     # Clones repository into current directory
-    $ glab repo clone gitlab-org/cli
-    $ glab repo clone https://gitlab.com/gitlab-org/cli
+    glab repo clone gitlab-org/cli
+    glab repo clone https://gitlab.com/gitlab-org/cli
 
     # Clones repository into 'mydirectory'
-    $ glab repo clone gitlab-org/cli mydirectory
+    glab repo clone gitlab-org/cli mydirectory
 
     # Clones a project's wiki repository
-    $ glab repo clone --wiki gitlab-org/cli
+    glab repo clone --wiki gitlab-org/cli
 
     # Clones repository 'glab' for current user
-    $ glab repo clone glab
+    glab repo clone glab
 
     # Finds the project by the ID provided and clones it
-    $ glab repo clone 4356677
+    glab repo clone 4356677
 
     # Clones a specific branch
-    $ glab repo clone gitlab-org/cli -- --branch development
+    glab repo clone gitlab-org/cli -- --branch development
 
     # Clones with a shallow clone (depth 1)
-    $ glab repo clone gitlab-org/cli -- --depth 1
+    glab repo clone gitlab-org/cli -- --depth 1
 
     # Clones with multiple Git flags
-    $ glab repo clone gitlab-org/cli -- --branch main --single-branch --depth 1
+    glab repo clone gitlab-org/cli -- --branch main --single-branch --depth 1
 
     # Clones all repos in a group
-    $ glab repo clone -g everyonecancontribute --paginate
+    glab repo clone -g everyonecancontribute --paginate
 
     # Clones all non-archived repos in a group
-    $ glab repo clone -g everyonecancontribute --archived=false --paginate
+    glab repo clone -g everyonecancontribute --archived=false --paginate
 
     # Clones only active projects in a group
-    $ glab repo clone -g everyonecancontribute --active=true --paginate
+    glab repo clone -g everyonecancontribute --active=true --paginate
 
     # Clones from a GitLab Self-Managed or GitLab Dedicated instance
-    $ GITLAB_HOST=salsa.debian.org glab repo clone myrepo
+    GITLAB_HOST=salsa.debian.org glab repo clone myrepo
 
   FLAGS
 

--- a/glab-repo/references/commands.md
+++ b/glab-repo/references/commands.md
@@ -74,50 +74,64 @@
 ## repo clone
 
 ```
+  Clone a GitLab repository to your local machine. Specify the
+  repository by name, namespace/repo path, full URL, or project ID.
 
-  Clone a GitLab repository to your local machine. Specify the repository by name,
-  namespace/repo path, full URL, or project ID.
+  The command uses your configured protocol (SSH or HTTPS).
+
+  To pass Git clone flags, add them after `--`. For example:
+  `glab repo clone <repo> -- --branch <branch-name>`
+
+  When you clone a fork you own, the command adds an `upstream`
+  remote that points to the parent project.
 
   Use `--wiki` to clone the wiki repository associated with a project.
-                                                                                                                        
-         
-  USAGE  
-         
-    glab repo clone <repo> glab repo clone -g <group> [<dir>] [-- <gitflags>...] [<dir>] [-- <gitflags>...] [--       
-    flags]                                                                                                            
-            
-  EXAMPLES  
-            
-    # Clones repository into current directory                                                                        
-    $ glab repo clone gitlab-org/cli                                                                                  
-    $ glab repo clone https://gitlab.com/gitlab-org/cli                                                               
-                                                                                                                      
+
+  USAGE
+
+    glab repo clone [<repo> | -g <group>] [<dir>]  [-- <gitflags>...] [--flags]
+
+  EXAMPLES
+
+    # Clones repository into current directory
+    $ glab repo clone gitlab-org/cli
+    $ glab repo clone https://gitlab.com/gitlab-org/cli
+
     # Clones repository into 'mydirectory'
     $ glab repo clone gitlab-org/cli mydirectory
 
     # Clones a project's wiki repository
     $ glab repo clone --wiki gitlab-org/cli
-                                                                                                                      
-    # Clones repository 'glab' for current user                                                                       
-    $ glab repo clone glab                                                                                            
-                                                                                                                      
-    # Finds the project by the ID provided and clones it                                                              
-    $ glab repo clone 4356677                                                                                         
-                                                                                                                      
-    # Clones all repos in a group                                                                                     
-    $ glab repo clone -g everyonecancontribute --paginate                                                             
-                                                                                                                      
-    # Clones all non-archived repos in a group                                                                        
-    $ glab repo clone -g everyonecancontribute --archived=false --paginate                                            
-                                                                                                                      
-    # Clones only active projects in a group                                                                          
-    $ glab repo clone -g everyonecancontribute --active=true --paginate                                               
-                                                                                                                      
-    # Clones from a GitLab Self-Managed or GitLab Dedicated instance                                                  
-    $ GITLAB_HOST=salsa.debian.org glab repo clone myrepo                                                             
-         
-  FLAGS  
-         
+
+    # Clones repository 'glab' for current user
+    $ glab repo clone glab
+
+    # Finds the project by the ID provided and clones it
+    $ glab repo clone 4356677
+
+    # Clones a specific branch
+    $ glab repo clone gitlab-org/cli -- --branch development
+
+    # Clones with a shallow clone (depth 1)
+    $ glab repo clone gitlab-org/cli -- --depth 1
+
+    # Clones with multiple Git flags
+    $ glab repo clone gitlab-org/cli -- --branch main --single-branch --depth 1
+
+    # Clones all repos in a group
+    $ glab repo clone -g everyonecancontribute --paginate
+
+    # Clones all non-archived repos in a group
+    $ glab repo clone -g everyonecancontribute --archived=false --paginate
+
+    # Clones only active projects in a group
+    $ glab repo clone -g everyonecancontribute --active=true --paginate
+
+    # Clones from a GitLab Self-Managed or GitLab Dedicated instance
+    $ GITLAB_HOST=salsa.debian.org glab repo clone myrepo
+
+  FLAGS
+
     -g --group                Specify the group to clone repositories from.
     -p --preserve-namespace   Clone the repository in a subdirectory based on namespace.
     --active                  Limit by project status. When true, returns active projects. When false, returns projects that are archived or marked for deletion. Used with the --group flag.

--- a/glab-repo/references/commands.md
+++ b/glab-repo/references/commands.md
@@ -75,12 +75,10 @@
 
 ```
 
-  Clone supports these shorthand references:                                                                            
-                                                                                                                        
-  - repo                                                                                                                
-  - namespace/repo                                                                                                      
-  - org/group/repo                                                                                                      
-  - project ID                                                                                                          
+  Clone a GitLab repository to your local machine. Specify the repository by name,
+  namespace/repo path, full URL, or project ID.
+
+  Use `--wiki` to clone the wiki repository associated with a project.
                                                                                                                         
          
   USAGE  
@@ -94,8 +92,11 @@
     $ glab repo clone gitlab-org/cli                                                                                  
     $ glab repo clone https://gitlab.com/gitlab-org/cli                                                               
                                                                                                                       
-    # Clones repository into 'mydirectory'                                                                            
-    $ glab repo clone gitlab-org/cli mydirectory                                                                      
+    # Clones repository into 'mydirectory'
+    $ glab repo clone gitlab-org/cli mydirectory
+
+    # Clones a project's wiki repository
+    $ glab repo clone --wiki gitlab-org/cli
                                                                                                                       
     # Clones repository 'glab' for current user                                                                       
     $ glab repo clone glab                                                                                            
@@ -130,6 +131,7 @@
     --paginate                Make additional HTTP requests to fetch all pages of projects before cloning. Respects --per-page.
     --page                    Page number. (1)
     --per-page                Number of items to list per page. (30)
+    --wiki                    Clone the project's wiki repository.
     -h --help                 Show help for this command.
 ```
 

--- a/glab-securefile/SKILL.md
+++ b/glab-securefile/SKILL.md
@@ -49,9 +49,15 @@ Use `--all` to download every secure file across all API pages; it is not limite
 ```bash
 # Download every secure file to a controlled directory
 glab securefile download --all --output-dir ./secure-files -R group/project
+
+# Download one file to an absolute path; glab creates missing parents
+glab securefile download 1 --path /tmp/secure/file.txt -R group/project
+
+# Download all files to an absolute directory
+glab securefile download --all --output-dir /tmp/secure-files -R group/project
 ```
 
-Treat the destination as sensitive, keep it outside version control, and verify the target project before downloading.
+Treat the destination as sensitive, keep it outside version control, and verify the target project before downloading. Absolute `--path` and `--output-dir` destinations are supported. For `--all`, glab rejects server-provided names that could escape the selected output directory.
 
 ## Removing secure files
 

--- a/glab-securefile/references/commands.md
+++ b/glab-securefile/references/commands.md
@@ -101,6 +101,9 @@
     # Download a file by ID to a specific path
     glab securefile download 1 --path "securefiles/file.txt"
 
+    # Download a file to an absolute path
+    glab securefile download 1 --path /tmp/secure/file.txt
+
     # Download a file by name to the current directory
     glab securefile download --name my-secure-file.pem
 

--- a/glab-stack/SKILL.md
+++ b/glab-stack/SKILL.md
@@ -48,6 +48,8 @@ glab stack --help
 
 ## Current behavior
 
+Generated stack branches use `{branch_prefix}-{stack-title}-{hash}`. If `branch_prefix` is unset, glab uses the operating system account username (and removes a Windows domain prefix), falling back to `glab-stack` only when user lookup is unavailable. It does not rely on `$USER`; set `glab config set branch_prefix <value>` when automation requires a stable explicit prefix.
+
 `glab stack infer <revision-range>` creates or appends stack layers from selected commits in a Git revision range. The start of the range must resolve to a branch name, not a relative ref such as `HEAD~5`, because the base branch is recorded in stack metadata.
 
 ```bash
@@ -83,6 +85,8 @@ Use `--update-base` when the base branch (for example `main`) has moved and you 
 Use `--skip-mr-creation` when you want to push amended stack branches and clean up merged/closed entries but intentionally avoid opening new merge requests for stack layers that do not have one yet.
 
 Use `--assignee`, `--reviewer`, and `--label` when you want `glab stack sync` to submit the stack's merge requests with ownership and routing metadata in the same step.
+
+During stack sync pushes, glab streams Git hook output to stdout/stderr as it runs. Preserve that output in automation logs: a failing pre-push hook is returned as the push error instead of being hidden behind buffered output.
 
 `glab stack switch` can now be run without a stack name to choose interactively from all stacks. Pass the stack name for non-interactive automation.
 


### PR DESCRIPTION
## Upstream

- GitLab CLI `glab` **v1.111.0**
- Canonical release: https://gitlab.com/gitlab-org/cli/-/releases/v1.111.0
- Canonical release API: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest

## CLI changes reviewed

- Authentication now uses the OS keyring by default on workstations, adds `--insecure-storage`, and improves OAuth/PAT isolation and reauthentication behavior.
- `glab issue board view` adds `--paginate`; `glab repo clone` adds `--wiki`.
- Non-interactive `glab mr create` accepts title-only creation, and MR note text output exposes reply-ready discussion prefixes.
- Package and secure-file downloads accept absolute destinations.
- JSON output emits structured error objects; nested project namespaces, stack branch-prefix resolution/hook output, and CI job ordering received automation-relevant fixes.

## Skill/package changes

- Updated the affected auth, API, issue, MR, repo, package, secure-file, stack, config, and CI guidance and command references.
- Bumped the skill package version from `1.13.19` to `1.13.20` in `VERSION` and recorded the refresh there.
- No repo-local scheduler, refresh engine, cron script, or GitHub Actions workflow was added.

## Validation

- Verified the downloaded Darwin arm64 release archive against GitLab's published SHA-256 checksums; binary reports `glab 1.111.0 (23893459)`.
- Compared live v1.110.0/v1.111.0 help and asserted the affected v1.111.0 auth, issue-board, repo, package, secure-file, MR-note, and config help surfaces.
- Parsed frontmatter for all 46 discoverable skills successfully.
- `npx --yes skills add . --list`: local path validated; 46 skills discovered.
- `bash scripts/build-claude-skill.sh`: built 45 sub-skills plus the top-level skill; archive verified to contain one `gitlab-cli-skills/SKILL.md` artifact with valid frontmatter.
- Markdown fence sanity check and `git diff --check` passed.

**Vince: please review this refresh before merge.**
