### PR TITLE
docs: refresh glab skills for v1.113.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A collection of skills for AI coding agents following the Agent Skills format. T
 - [`glab-auth`](./glab-auth)
 - [`glab-alias`](./glab-alias)
 - [`glab-api`](./glab-api)
+- [`glab-artifact-registry`](./glab-artifact-registry)
 - [`glab-attestation`](./glab-attestation)
 - [`glab-changelog`](./glab-changelog)
 - [`glab-check-update`](./glab-check-update)

--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,13 @@
-1.13.21
+1.13.22
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.22
+  - glab v1.113.0 refresh: added standalone guidance and checksum-verified help for experimental `glab artifact-registry get-token` and `status`, including token-output handling, duration limits, GitLab EE 19.1 prerequisites, and token-exchange feature-flag requirements.
+  - Updated `glab api --field` guidance for JSON arrays/objects, nested placeholder expansion, invalid/trailing JSON failures, and the corrected literal behavior of bracketed `--raw-field` values.
+  - Documented flag-complete `glab mr create` outside a local Git checkout, the OAuth-environment-token scheme hint, and non-destructive Docker credential-helper registration behavior.
+  - Reviewed OAuth refresh contention, CI rendering, argument-count, and issue/MR behavior fixes; no additional command surface changes were required.
 - v1.13.21
   - Added standalone guidance and captured help for the beta `glab dependency-firewall` / `glab df` command group, including npm registry configuration, current-working-directory behavior, and CI summary exit codes.
   - Updated authentication troubleshooting for environment-token precedence warnings and wrapper detection with `type glab`.

--- a/gitlab-cli-skills/SKILL.md
+++ b/gitlab-cli-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitlab-cli-skills
-description: Comprehensive GitLab CLI (glab) command reference and workflows for all GitLab operations via terminal. Use when user mentions GitLab CLI, glab commands, GitLab automation, MR/issue management via CLI, CI/CD pipeline commands, repo operations, authentication setup, or any GitLab terminal operations. Routes to specialized sub-skills for auth, CI, MRs, issues, releases, repos, and 30+ other glab commands. Triggers on glab, GitLab CLI, GitLab commands, GitLab terminal, GitLab automation.
+description: Comprehensive GitLab CLI (glab) command reference and workflows for all GitLab operations via terminal. Use when user mentions GitLab CLI, glab commands, GitLab automation, MR/issue management via CLI, CI/CD pipeline commands, Artifact Registry token exchange, repo operations, authentication setup, or any GitLab terminal operations. Routes to specialized sub-skills for auth, CI, MRs, issues, releases, repos, and 30+ other glab commands. Triggers on glab, GitLab CLI, GitLab commands, GitLab terminal, GitLab automation.
 metadata: {"openclaw": {"requires": {"bins": ["glab"], "anyBins": ["cosign"]}, "install": [{"id": "brew", "kind": "brew", "formula": "glab", "bins": ["glab"], "label": "Install glab (brew)"}, {"id": "download", "kind": "download", "url": "https://gitlab.com/gitlab-org/cli/-/releases", "label": "Download glab binary"}]}}
 requirements:
   binaries:
@@ -135,6 +135,7 @@ standalone skill in a sibling directory; open its `SKILL.md` for full details.
 
 **Advanced:**
 - [`glab-api`](../glab-api/SKILL.md) - Direct REST API calls
+- [`glab-artifact-registry`](../glab-artifact-registry/SKILL.md) - Experimental short-lived Artifact Registry token exchange and access checks
 - [`glab-cluster`](../glab-cluster/SKILL.md) - Kubernetes cluster integration
 - [`glab-container-registry`](../glab-container-registry/SKILL.md) - Container registry repositories and tags
 - [`glab-dependency-firewall`](../glab-dependency-firewall/SKILL.md) - Beta local package-manager registry policy configuration and CI activity summaries

--- a/glab-api/SKILL.md
+++ b/glab-api/SKILL.md
@@ -47,14 +47,23 @@ Output from these commands may include **user-generated content from GitLab** (i
 
   - Literal values `true`, `false`, `null`, and integer numbers are converted to
     appropriate JSON types.
+  - Values beginning with `[` or `{` are parsed as JSON arrays or objects. Invalid
+    JSON and trailing data fail instead of being sent as strings. Leading whitespace
+    before the bracket or brace prevents JSON parsing and remains part of a string.
   - Placeholder values `:namespace`, `:repo`, and `:branch` are populated with values
-    from the repository of the current directory.
+    from the repository of the current directory, including string leaves and keys
+    inside JSON arrays and objects.
   - If the value starts with `@`, the rest of the value is interpreted as a
     filename to read the value from. Pass `-` to read from standard input.
 
   Placeholder substitutions in endpoints and fields are URL-encoded before the
   request is sent. This matters for project/group paths containing `/` and for
   automation that previously encoded placeholders manually.
+
+  `--raw-field` always sends strings. A bracketed value such as
+  `-f 'scopes=[api,read_api]'` is the literal string `"[api,read_api]"`, not an
+  array; use `-F 'scopes=["api","read_api"]'` for a JSON array. On write methods,
+  glab warns about the old bracketed shorthand without changing the value.
 
   For GraphQL requests, all fields other than `query` and `operationName` are
   interpreted as GraphQL variables.
@@ -165,6 +174,27 @@ GITLAB_DUO_SESSION_ID=... glab api projects/:fullpath
 These become `X-Gitlab-Duo-Workflow-Id` and `X-Gitlab-Duo-Session-Id` respectively. Do not invent or spoof these values; preserve them only when the surrounding GitLab Duo workflow/session supplied them.
 
 Magic placeholders such as `:fullpath`, `:namespace`, `:repo`, and `:branch` are URL-encoded by `glab` during substitution. Prefer placeholders over manual string interpolation when possible, and avoid double-encoding values that `glab` will substitute.
+
+### Structured values with `--field`
+
+Use `--field` (`-F`) when an endpoint expects an array or object. Quote the whole
+shell argument so the JSON reaches glab unchanged:
+
+```bash
+# JSON array
+glab api projects/:fullpath --method PUT \
+  -F 'topics=["platform","GitLab"]'
+
+# Nested object; placeholders expand inside JSON strings
+glab api graphql \
+  -F 'query=mutation($input: ProjectInput!) { updateProject(input: $input) { errors } }' \
+  -F 'input={"projectPath":":fullpath","labels":["automation"]}'
+```
+
+The value must begin immediately with `[` or `{`. Invalid JSON, trailing data,
+or object-key collisions created by placeholder expansion are rejected. Use
+`--input` for a complete request body or when a JSON document is easier to
+review as a file. Use `--raw-field` only for an intentional string.
 
 ## Built-in JSON filtering with `--jq`
 

--- a/glab-artifact-registry/SKILL.md
+++ b/glab-artifact-registry/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: glab-artifact-registry
+description: Exchange GitLab credentials for short-lived Artifact Registry tokens and verify token identity with glab. Use when checking GitLab Artifact Registry access, obtaining an ephemeral registry token, or feeding a short-lived token to a registry client. Triggers on artifact registry, glab artifact-registry, get-token, token exchange, registry access status.
+---
+
+# glab artifact-registry
+
+Exchange the active GitLab credential for a short-lived Artifact Registry access token. This command group is experimental; verify live help and the target GitLab instance before using it in durable automation.
+
+## Prerequisites
+
+- GitLab Enterprise Edition 19.1 or later.
+- The instance administrator enabled the `gate_token_exchange_endpoint` feature flag.
+- `glab` is authenticated to the intended hostname.
+
+The token is ephemeral but still a credential. Never print it in logs, store it in a repository, include it in command arguments, or paste it into issue/MR content.
+
+## Check access first
+
+`status` performs the token exchange and prints non-secret identity metadata: issuer, subject, audience, and expiry. Each check mints and immediately discards a server-side token; prefer JSON for automation and do not call it in a tight loop.
+
+```bash
+glab artifact-registry status --hostname gitlab.example.com --output json
+
+# Extract only non-secret expiry metadata
+glab artifact-registry status \
+  --hostname gitlab.example.com \
+  --output json \
+  --jq '.expires_at'
+```
+
+Confirm that the issuer, subject, and audience identify the intended instance, actor, and registry before requesting a token for another process.
+
+## Request a short-lived token
+
+Text output is the bare token on stdout so a shell can capture or pipe it. Default duration is 15 minutes; accepted durations range from 1 second through 12 hours. Use the shortest duration that covers the operation.
+
+```bash
+# Avoid command tracing and keep the token only in a process-local variable
+set +x
+artifact_token="$(glab artifact-registry get-token \
+  --hostname gitlab.example.com \
+  --duration 15m)"
+
+# Feed via stdin, not as a command-line argument. Obtain the registry host and
+# required username from the target registry's documentation or administrator.
+printf '%s' "$artifact_token" | \
+  docker login <artifact-registry-host> \
+    --username '<registry-username>' \
+    --password-stdin
+unset artifact_token
+```
+
+Use `--output json` only when a consumer also needs the expiry. Treat the JSON document as secret because it contains the token. Do not pass `--jq` expressions that print the token into logs.
+
+## Troubleshooting
+
+- **Unsupported or not found:** verify GitLab EE 19.1+ and the `gate_token_exchange_endpoint` feature flag with the instance administrator.
+- **Wrong issuer/subject/audience:** stop; re-check `--hostname`, environment-token precedence, and `glab auth status --hostname <host>`.
+- **Duration rejected:** use a Go-style duration between `1s` and `12h`.
+- **Expired token:** request a new short-lived token; do not persist or attempt to refresh the old one.
+
+See [references/commands.md](references/commands.md) for captured command help.

--- a/glab-artifact-registry/SKILL.md
+++ b/glab-artifact-registry/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: glab-artifact-registry
-description: Exchange GitLab credentials for short-lived Artifact Registry tokens and verify token identity with glab. Use when checking GitLab Artifact Registry access, obtaining an ephemeral registry token, or feeding a short-lived token to a registry client. Triggers on artifact registry, glab artifact-registry, get-token, token exchange, registry access status.
+description: Exchange GitLab credentials for short-lived Artifact Registry tokens and verify token identity with glab. Use when checking GitLab Artifact Registry access, obtaining an ephemeral registry token, or feeding a short-lived token to a registry client. Triggers on artifact registry, glab artifact-registry, glab ar, get-token, token exchange, registry access status.
 ---
 
 # glab artifact-registry
 
-Exchange the active GitLab credential for a short-lived Artifact Registry access token. This command group is experimental; verify live help and the target GitLab instance before using it in durable automation.
+Exchange the active GitLab credential for a short-lived Artifact Registry access token. The command group also accepts the `glab ar` alias. This command group is experimental; verify live help and the target GitLab instance before using it in durable automation.
 
 ## Prerequisites
 

--- a/glab-artifact-registry/references/commands.md
+++ b/glab-artifact-registry/references/commands.md
@@ -5,58 +5,114 @@
 ## artifact-registry
 
 ```text
-Exchange a GitLab credential for a short-lived Artifact Registry access token,
-either to check your access or to hand the token to a caller.
 
-This feature is an experiment and is not ready for production use.
+  Exchange a GitLab credential for a short-lived Artifact Registry access
+  token, either to check your access or to hand the token to a caller.
 
-Usage:
-  glab artifact-registry <command> [command] [--flags]
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
 
-Commands:
-  get-token [--flags]  Get a short-lived access token for the GitLab Artifact Registry. (EXPERIMENTAL)
-  status [--flags]     Check your access to the GitLab Artifact Registry. (EXPERIMENTAL)
+
+  USAGE
+
+    glab artifact-registry <command> [command] [--flags]
+
+  COMMANDS
+
+    get-token [--flags]  Get a short-lived access token for the GitLab Artifact Registry. (EXPERIMENTAL)
+    status [--flags]     Check your access to the GitLab Artifact Registry. (EXPERIMENTAL)
+
+  FLAGS
+
+    -h --help            Show help for this command.
+
 ```
 
 ## artifact-registry get-token
 
 ```text
-Exchange a GitLab credential for a short-lived access token scoped to the
-GitLab Artifact Registry. The command prints the bare token to stdout.
 
-Prerequisites:
-- GitLab Enterprise Edition (EE) 19.1 or later.
-- Token exchange enabled (`gate_token_exchange_endpoint`).
+  Exchange a GitLab credential for a short-lived access token scoped to the
+  GitLab Artifact Registry. The command prints the bare token to stdout,
+  so a shell can capture it directly, for example to feed `docker login`.
 
-Usage:
-  glab artifact-registry get-token [--flags]
+  Prerequisites:
 
-Flags:
-  --duration   How long the token should remain valid. Must be between 1s and 12h0m0s. (15m0s)
-  -h --help    Show help for this command.
-  --hostname   Gitlab hostname to request the token from. Defaults to the configured GitLab instance.
-  --jq         Filter JSON output with a jq expression.
-  -F --output  Format output as: text, json. (text)
+  - A GitLab Enterprise Edition (EE) instance on GitLab 19.1 or later.
+  - Token exchange enabled on the instance (the
+    `gate_token_exchange_endpoint` feature flag).
+
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab artifact-registry get-token [--flags]
+
+  EXAMPLES
+
+    # Get a token using the default duration
+    glab artifact-registry get-token
+
+    # Get a token valid for one hour
+    glab artifact-registry get-token --duration 1h
+
+    # Get a token as JSON, including its expiry
+    glab artifact-registry get-token --output json
+
+  FLAGS
+
+    --duration   How long the token should remain valid. Must be between 1s and 12h0m0s. (15m0s)
+    -h --help    Show help for this command.
+    --hostname   Gitlab hostname to request the token from. Defaults to the configured GitLab instance.
+    --jq         Filter JSON output with a jq expression.
+    -F --output  Format output as: text, json. (text)
+
 ```
 
 ## artifact-registry status
 
 ```text
-Exchange a GitLab credential for a short-lived Artifact Registry access token,
-then print the token's issuer, subject, audience, and expiry so you can confirm
-which identity and instance you are authenticated as. No credentials are
-written to disk.
 
-Prerequisites:
-- GitLab Enterprise Edition (EE) 19.1 or later.
-- Token exchange enabled (`gate_token_exchange_endpoint`).
+  Exchange a GitLab credential for a short-lived Artifact Registry access
+  token, then print the token's issuer, subject, audience, and expiry so
+  you can confirm which identity and instance you are authenticated as. No
+  credentials are written to disk.
 
-Usage:
-  glab artifact-registry status [--flags]
+  Prerequisites:
 
-Flags:
-  -h --help    Show help for this command.
-  --hostname   Gitlab hostname to check. Defaults to the configured GitLab instance.
-  --jq         Filter JSON output with a jq expression.
-  -F --output  Format output as: text, json. (text)
+  - A GitLab Enterprise Edition (EE) instance on GitLab 19.1 or later.
+  - Token exchange enabled on the instance (the
+    `gate_token_exchange_endpoint` feature flag).
+
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab artifact-registry status [--flags]
+
+  EXAMPLES
+
+    # Show Artifact Registry access status
+    glab artifact-registry status
+
+    # Show Artifact Registry access status as JSON
+    glab artifact-registry status --output json
+
+  FLAGS
+
+    -h --help    Show help for this command.
+    --hostname   Gitlab hostname to check. Defaults to the configured GitLab instance.
+    --jq         Filter JSON output with a jq expression.
+    -F --output  Format output as: text, json. (text)
+
 ```

--- a/glab-artifact-registry/references/commands.md
+++ b/glab-artifact-registry/references/commands.md
@@ -1,0 +1,62 @@
+# glab artifact-registry command reference
+
+> Help captured from the checksum-verified glab v1.113.0 macOS arm64 release binary.
+
+## artifact-registry
+
+```text
+Exchange a GitLab credential for a short-lived Artifact Registry access token,
+either to check your access or to hand the token to a caller.
+
+This feature is an experiment and is not ready for production use.
+
+Usage:
+  glab artifact-registry <command> [command] [--flags]
+
+Commands:
+  get-token [--flags]  Get a short-lived access token for the GitLab Artifact Registry. (EXPERIMENTAL)
+  status [--flags]     Check your access to the GitLab Artifact Registry. (EXPERIMENTAL)
+```
+
+## artifact-registry get-token
+
+```text
+Exchange a GitLab credential for a short-lived access token scoped to the
+GitLab Artifact Registry. The command prints the bare token to stdout.
+
+Prerequisites:
+- GitLab Enterprise Edition (EE) 19.1 or later.
+- Token exchange enabled (`gate_token_exchange_endpoint`).
+
+Usage:
+  glab artifact-registry get-token [--flags]
+
+Flags:
+  --duration   How long the token should remain valid. Must be between 1s and 12h0m0s. (15m0s)
+  -h --help    Show help for this command.
+  --hostname   Gitlab hostname to request the token from. Defaults to the configured GitLab instance.
+  --jq         Filter JSON output with a jq expression.
+  -F --output  Format output as: text, json. (text)
+```
+
+## artifact-registry status
+
+```text
+Exchange a GitLab credential for a short-lived Artifact Registry access token,
+then print the token's issuer, subject, audience, and expiry so you can confirm
+which identity and instance you are authenticated as. No credentials are
+written to disk.
+
+Prerequisites:
+- GitLab Enterprise Edition (EE) 19.1 or later.
+- Token exchange enabled (`gate_token_exchange_endpoint`).
+
+Usage:
+  glab artifact-registry status [--flags]
+
+Flags:
+  -h --help    Show help for this command.
+  --hostname   Gitlab hostname to check. Defaults to the configured GitLab instance.
+  --jq         Filter JSON output with a jq expression.
+  -F --output  Format output as: text, json. (text)
+```

--- a/glab-artifact-registry/references/commands.md
+++ b/glab-artifact-registry/references/commands.md
@@ -69,7 +69,7 @@
 
     --duration   How long the token should remain valid. Must be between 1s and 12h0m0s. (15m0s)
     -h --help    Show help for this command.
-    --hostname   Gitlab hostname to request the token from. Defaults to the configured GitLab instance.
+    --hostname   GitLab hostname to request the token from. Defaults to the configured GitLab instance.
     --jq         Filter JSON output with a jq expression.
     -F --output  Format output as: text, json. (text)
 
@@ -111,7 +111,7 @@
   FLAGS
 
     -h --help    Show help for this command.
-    --hostname   Gitlab hostname to check. Defaults to the configured GitLab instance.
+    --hostname   GitLab hostname to check. Defaults to the configured GitLab instance.
     --jq         Filter JSON output with a jq expression.
     -F --output  Format output as: text, json. (text)
 

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -185,6 +185,14 @@ If the wrong-identity write changed state beyond a comment or reply, re-auth as 
    docker pull registry.gitlab.com/group/project/image:tag
    ```
 
+`configure-docker` adds glab only for the configured GitLab registry domains.
+It preserves unrelated Docker credential helpers and refuses to replace a
+different helper already assigned to the same domain. If a domain has legacy
+credentials from `docker login`, glab warns that the helper takes precedence;
+after verifying helper-based access, use the exact suggested `docker logout
+<domain>` command to remove the shadowed entry. Back up and review
+`$DOCKER_CONFIG/config.json` before repairing conflicts manually.
+
 ## Troubleshooting
 
 **"401 Unauthorized" errors:**
@@ -199,6 +207,7 @@ If the wrong-identity write changed state beyond a comment or reply, re-auth as 
 **Env-token auth failures:**
 - If `GITLAB_TOKEN`, `GITLAB_ACCESS_TOKEN`, or `OAUTH_TOKEN` is exported, it overrides stored credentials.
 - `GITLAB_TOKEN` and `GITLAB_ACCESS_TOKEN` are treated as personal access tokens independently of a stored OAuth profile, so a temporary PAT does not inherit or refresh saved OAuth state.
+- If the host is configured for OAuth but an environment variable contains an OAuth access token, set `GLAB_IS_OAUTH2=true`; otherwise glab sends the environment token as a personal access token. `glab auth status` reports this scheme mismatch after a 401.
 - If auth suddenly fails, check whether an env token is being picked up before assuming your saved login is broken. `glab auth login` and `glab auth status` warn when this precedence applies.
 - Run `type glab` to distinguish a wrapper that intentionally injects a token (for example, a 1Password shell plugin alias) from a plain executable path. A wrapper can be expected and need no action; a plain path means the token came from the shell profile, current environment, or CI variables.
 - These failures can affect both read operations and writes, not just write pre-flight checks.

--- a/glab-auth/references/commands.md
+++ b/glab-auth/references/commands.md
@@ -149,11 +149,13 @@ Verifies and displays information about your authentication state.
 ## configure-docker
 
 ```
-Configures Docker to use glab for authentication with GitLab container
-registries. This command runs only on Linux and macOS.
 
-After you run this command, Docker uses glab to obtain credentials when it
-pulls from or pushes to a GitLab container registry.
+  Configures Docker to use glab for authentication with GitLab
+  container registries. This command runs only on Linux and macOS.
+
+  After you run this command, Docker uses glab to obtain credentials
+  when it pulls from or pushes to a GitLab container registry.
+
 
   USAGE
 
@@ -167,6 +169,7 @@ pulls from or pushes to a GitLab container registry.
   FLAGS
 
     -h --help  Show help for this command.
+
 ```
 
 ## docker-helper

--- a/glab-auth/references/commands.md
+++ b/glab-auth/references/commands.md
@@ -149,11 +149,20 @@ Verifies and displays information about your authentication state.
 ## configure-docker
 
 ```
-Register glab as a Docker credential helper
+Configures Docker to use glab for authentication with GitLab container
+registries. This command runs only on Linux and macOS.
+
+After you run this command, Docker uses glab to obtain credentials when it
+pulls from or pushes to a GitLab container registry.
 
   USAGE
 
     glab auth configure-docker [--flags]
+
+  EXAMPLES
+
+    # Configure Docker to use glab for GitLab container registry authentication
+    glab auth configure-docker
 
   FLAGS
 

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -50,6 +50,33 @@ GLAB_NO_PROMPT=1 glab mr create \
   --yes
 ```
 
+**Without a local Git checkout:**
+
+`glab mr create` can create an MR outside a Git repository when every remote-
+dependent input is supplied as a flag. The source branch must already exist on
+the selected source project. Do not use `--push`, `--fill`, or `--template`,
+because those require local repository state.
+
+```bash
+glab mr create \
+  --repo group/project \
+  --source-branch feature-branch \
+  --target-branch main \
+  --title "Add feature" \
+  --description "Details..." \
+  --yes
+
+# Fork source into an upstream target
+glab mr create \
+  --repo upstream/project \
+  --head your-namespace/project \
+  --source-branch feature-branch \
+  --target-branch main \
+  --title "Add feature" \
+  --description "Details..." \
+  --yes
+```
+
 **From issue:**
 ```bash
 glab mr for 456  # Creates MR linked to issue #456

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -52,8 +52,8 @@ GLAB_NO_PROMPT=1 glab mr create \
 
 **Without a local Git checkout:**
 
-`glab mr create` can create an MR outside a Git repository when every remote-
-dependent input is supplied as a flag. The source branch must already exist on
+`glab mr create` can create an MR outside a Git repository when every
+remote-dependent input is supplied as a flag. The source branch must already exist on
 the selected source project. Do not use `--push`, `--fill`, or `--template`,
 because those require local repository state.
 

--- a/glab-mr/references/commands.md
+++ b/glab-mr/references/commands.md
@@ -174,7 +174,15 @@
 
 ```
 
-  Create a new merge request.
+  Defaults to the current branch as the source branch. Use `--fill`
+  to automatically fill the title and description from the commit history. Use
+  `--draft` to create a draft merge request.
+
+  The `--recover` flag is an experiment: it might be unstable or
+  removed at any time, and is not ready for production use. For more
+  information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
 
   USAGE
 
@@ -191,17 +199,25 @@
     # Fill title and description from commits, mark as draft, add a label
     glab mr create -f --draft --label RFC
 
-    # Create against another project without a local clone. All inputs must be
-    # passed as flags; no --push, --fill, or --template.
-    glab mr create --repo group/project --source-branch feature-branch --target-branch main --title "Add feature" --description "Details..." --yes
+    # Fill from commits and preview the compare page in the browser
+    glab mr create --fill --web
 
-    # Create a fork merge request from your fork into the upstream project,
-    # without a local clone.
-    glab mr create --repo upstream/project --head your-namespace/project --source-branch feature-branch --target-branch main --title "Add feature" --description "Details..." --yes
+    # Fill from commits, expand each commit body into the description
+    glab mr create --fill --fill-commit-body --yes
+
+    # Use a merge request template for the description
+    glab mr create -t "Fix login bug" --template bug_fix
+    glab mr create -t "Security patch" --template security_fix.md --yes
+
+    # Create against another project without a local clone. All inputs must be passed as flags; no --push, --fill, …
+    glab mr create --repo group/project --source-branch feature-branch --target-branch main --title "Add feature" -…
+
+    # Create a fork merge request from your fork into the upstream project, without a local clone.
+    glab mr create --repo upstream/project --head your-namespace/project --source-branch feature-branch --target-br…
 
   FLAGS
 
-    --allow-collaboration   Allow commits from other members.
+    --allow-collaboration   Allow commits from other members. Set to true/false to override project defaults, or omit to use project settings.
     -a --assignee           Assign merge request to people by their `usernames`. Multiple usernames can be comma-separated or specified by repeating the flag.
     --auto-merge            Set the merge request to merge when all merge checks pass.
     --copy-issue-labels     Copy labels from issue to the merge request. Used with --related-issue.
@@ -218,18 +234,19 @@
     --push                  Push committed changes after creating merge request. Make sure you have committed changes.
     --recover               Save the options to a file if the merge request creation fails. If the file exists, the options are loaded from the recovery file. (EXPERIMENTAL)
     -i --related-issue      Create a merge request for an issue. If --title is not provided, uses the issue title.
-    --remove-source-branch  Remove source branch on merge.
-    -R --repo               Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    --remove-source-branch  Remove source branch on merge. Set to true/false to override project defaults, or omit to use project settings.
+    -R --repo               Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
     --reviewer              Request review from users by their `usernames`. Multiple usernames can be comma-separated or specified by repeating the flag.
     --signoff               Append a DCO signoff to the merge request description.
     -s --source-branch      Create a merge request from this branch. Default is the current branch.
-    --squash-before-merge   Squash commits into a single commit when merging.
+    --squash-before-merge   Squash commits into a single commit when merging. Set to true/false to override project defaults, or omit to use project settings.
     -b --target-branch      The target or base branch into which you want your code merged into.
     --template              Name of a template in '.gitlab/merge_request_templates/' to pre-populate the description. The '.md' extension is optional. Templates are loaded from the local repository only.
     -t --title              Supply a title for the merge request.
     -w --web                Continue merge request creation in a browser.
     --wip                   Mark merge request as a draft. Alternative to --draft.
     -y --yes                Skip submission confirmation prompt. Use --fill to skip all optional prompts.
+
 ```
 
 ## mr delete

--- a/glab-mr/references/commands.md
+++ b/glab-mr/references/commands.md
@@ -182,11 +182,22 @@
 
   EXAMPLES
 
-    $ glab mr new
-    $ glab mr create -a username -t "fix annoying bug"
-    $ glab mr create -f --draft --label RFC
-    $ glab mr create --fill --web
-    $ glab mr create --fill --fill-commit-body --yes
+    # Create a merge request interactively from the current branch
+    glab mr new
+
+    # Assign a user and set a title without prompting for description
+    glab mr create -a username -t "fix annoying bug"
+
+    # Fill title and description from commits, mark as draft, add a label
+    glab mr create -f --draft --label RFC
+
+    # Create against another project without a local clone. All inputs must be
+    # passed as flags; no --push, --fill, or --template.
+    glab mr create --repo group/project --source-branch feature-branch --target-branch main --title "Add feature" --description "Details..." --yes
+
+    # Create a fork merge request from your fork into the upstream project,
+    # without a local clone.
+    glab mr create --repo upstream/project --head your-namespace/project --source-branch feature-branch --target-branch main --title "Add feature" --description "Details..." --yes
 
   FLAGS
 
@@ -214,6 +225,7 @@
     -s --source-branch      Create a merge request from this branch. Default is the current branch.
     --squash-before-merge   Squash commits into a single commit when merging.
     -b --target-branch      The target or base branch into which you want your code merged into.
+    --template              Name of a template in '.gitlab/merge_request_templates/' to pre-populate the description. The '.md' extension is optional. Templates are loaded from the local repository only.
     -t --title              Supply a title for the merge request.
     -w --web                Continue merge request creation in a browser.
     --wip                   Mark merge request as a draft. Alternative to --draft.


### PR DESCRIPTION
## Upstream

- GitLab CLI **v1.113.0**
- Canonical release API: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest
- Release: https://gitlab.com/gitlab-org/cli/-/releases/v1.113.0

## CLI changes reviewed

- Added experimental `glab artifact-registry get-token` and `status` token-exchange commands.
- `glab api --field` now parses JSON arrays/objects, expands nested placeholders, and rejects invalid/trailing JSON; bracketed `--raw-field` values remain literal strings.
- `glab mr create` supports flag-complete operation without a local clone.
- Auth diagnostics now flag OAuth environment-token scheme mismatches; Docker helper configuration preserves unrelated helpers and reports shadowed legacy logins.
- Reviewed remaining v1.113.0 OAuth-refresh, CI rendering, argument-count, and issue/MR fixes; they require no additional skill workflow changes.

## Skill/package changes

- Added standalone `glab-artifact-registry` guidance and captured help with secret-safe token handling.
- Updated `glab-api`, `glab-auth`, and `glab-mr` guidance/reference content.
- Added the new skill to README/orchestrator discovery and bumped the package audit version to **1.13.22**.
- No repo-local scheduler, refresh engine, or GitHub Actions automation was added.

## Validation

- Checksum-verified v1.113.0 macOS arm64 binary help assertions: passed.
- Frontmatter, skill-directory names, Markdown fences, and relative links across 48 skills: passed.
- `git diff --check`: passed.
- `scripts/build-claude-skill.sh`: passed; merged 47 sub-skills plus orchestrator, and verified the new skill/corrected fields in the ZIP.
- `npx skills add . --list`: discovered orchestrator and new/relevant standalone skills.
- Exact selective install of `glab-artifact-registry`: verified, then temporary install artifacts were removed.
- Shell syntax for the package build script: passed.

**Vince: please review this refresh; do not merge automatically.**
