### PR TITLE
docs(glab-runner): correct a flag used to list all runners for a given gitlab instance (`--all` -> `--instance`)

### DIFF
--- a/glab-runner/SKILL.md
+++ b/glab-runner/SKILL.md
@@ -32,7 +32,7 @@ glab runner list
 glab runner list --repo owner/project
 
 # List all runners (instance-level, admin only)
-glab runner list --all
+glab runner list --instance
 
 # Output as JSON
 glab runner list --output json
@@ -204,7 +204,7 @@ Commands:
   update    Update runner settings, including pause/unpause
 
 Flags (list):
-  --all          List all runners (instance-level, admin only)
+  --instance     List all runners available to the user (instance scope)
   --output       Format output as: text, json
   --page         Page number
   --per-page     Number of items per page


### PR DESCRIPTION
## Problem
`glab runner list --all` is rejected as an unknown flag.
The correct flag (per glab cli help) to list all runners associated with a gitlab instance is `--instance`.

## Fix
- Replace `glab runner list --all` with `glab runner list --instance`.
- Update the command reference to match the current CLI help.

## Validation
- Confirmed with `glab 1.111.0`, and with reference to docs for 1.113.0 (which isn't packaged yet for nixos).
- `glab runner list --help` documents `-i, --instance`.
- Parser probes reject `--all` before and after `--help`, and in the final argument position.