### PR TITLE
docs: refresh glab skills for v1.114.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,13 @@
-1.13.22
+1.13.23
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.23
+  - glab v1.114.0 refresh: added experimental `artifact-registry login --docker` guidance and checksum-verified help, including stored-token requirements, Docker config targeting, registry classification, helper conflicts, and fresh per-request token exchange.
+  - Updated Duo CLI guidance and complete help for interactive and headless `run --goal` modes, wrapper versus installed-binary help, prerequisites, and bounded-agent safety.
+  - Documented dynamic per-host proxy headers from literals, environment variables, or bounded helper commands; source/target branch rendering in `mr view`; and corrected masked/hidden group-variable writes.
+  - Re-captured all affected artifact-registry, Duo, and MR-view help surfaces from the verified binary. Terminal padding was removed, and the renderer's `Gitlab` typo was deliberately normalized to canonical `GitLab` in three Artifact Registry flag descriptions.
 - v1.13.22
   - glab v1.113.0 refresh: added standalone guidance and checksum-verified help for experimental `glab artifact-registry get-token` and `status`, including token-output handling, duration limits, GitLab EE 19.1 prerequisites, and token-exchange feature-flag requirements.
   - Updated `glab api --field` guidance for JSON arrays/objects, nested placeholder expansion, invalid/trailing JSON failures, and the corrected literal behavior of bracketed `--raw-field` values.

--- a/glab-artifact-registry/SKILL.md
+++ b/glab-artifact-registry/SKILL.md
@@ -72,7 +72,7 @@ glab artifact-registry login \
 Safety and compatibility rules:
 
 - `--registry` must be a bare hostname, optionally with a port. Do not pass a URL or path.
-- The helper subprocess reads a token stored by `glab auth login`; it intentionally ignores `GITLAB_TOKEN`. Store authentication for the selected host before configuring Docker.
+- The helper subprocess intentionally ignores `GITLAB_TOKEN`. It normally reads a token stored by `glab auth login`; inside a GitLab CI job, it also honors `CI_JOB_TOKEN` when CI auto-login is enabled with `GLAB_ENABLE_CI_AUTOLOGIN=true`. Outside that CI path, store authentication for the selected host before configuring Docker.
 - Use this only for a registry actually backed by GitLab Artifact Registry. Misclassifying a normal container registry can make every pull fail because an exchanged Artifact Registry token takes precedence.
 - The command writes `${DOCKER_CONFIG:-$HOME/.docker}/config.json`. Review that file's location first. It refuses to replace another per-registry credential helper, preserves existing `docker login` data, and reports when the new helper shadows that data.
 - Re-running the command for the same registry is safe and idempotent. After configuration, test a non-destructive pull or registry operation against the intended host without printing credentials.

--- a/glab-artifact-registry/SKILL.md
+++ b/glab-artifact-registry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-artifact-registry
-description: Exchange GitLab credentials for short-lived Artifact Registry tokens and verify token identity with glab. Use when checking GitLab Artifact Registry access, obtaining an ephemeral registry token, or feeding a short-lived token to a registry client. Triggers on artifact registry, glab artifact-registry, glab ar, get-token, token exchange, registry access status.
+description: Exchange GitLab credentials for short-lived Artifact Registry tokens, verify token identity, and configure Docker's credential helper with glab. Use when checking GitLab Artifact Registry access, obtaining an ephemeral registry token, or configuring Docker for a GitLab Artifact Registry. Triggers on artifact registry, glab artifact-registry, glab ar, get-token, token exchange, registry access status, artifact-registry login, Docker credential helper.
 ---
 
 # glab artifact-registry
@@ -53,11 +53,37 @@ unset artifact_token
 
 Use `--output json` only when a consumer also needs the expiry. Treat the JSON document as secret because it contains the token. Do not pass `--jq` expressions that print the token into logs.
 
+## Configure Docker credential exchange
+
+`glab artifact-registry login --docker` installs the `docker-credential-glab` shim and registers `glab` under Docker's per-registry `credHelpers`. Docker then exchanges a fresh short-lived token for every pull or push, so `--duration` is currently ignored.
+
+```bash
+# Inspect the intended Docker config and stored GitLab identity first
+printf 'Docker config: %s\n' "${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+glab auth status --hostname gitlab.example.com
+
+# Configure only the verified Artifact Registry hostname
+glab artifact-registry login \
+  --hostname gitlab.example.com \
+  --docker \
+  --registry registry.example.com
+```
+
+Safety and compatibility rules:
+
+- `--registry` must be a bare hostname, optionally with a port. Do not pass a URL or path.
+- The helper subprocess reads a token stored by `glab auth login`; it intentionally ignores `GITLAB_TOKEN`. Store authentication for the selected host before configuring Docker.
+- Use this only for a registry actually backed by GitLab Artifact Registry. Misclassifying a normal container registry can make every pull fail because an exchanged Artifact Registry token takes precedence.
+- The command writes `${DOCKER_CONFIG:-$HOME/.docker}/config.json`. Review that file's location first. It refuses to replace another per-registry credential helper, preserves existing `docker login` data, and reports when the new helper shadows that data.
+- Re-running the command for the same registry is safe and idempotent. After configuration, test a non-destructive pull or registry operation against the intended host without printing credentials.
+
 ## Troubleshooting
 
 - **Unsupported or not found:** verify GitLab EE 19.1+ and the `gate_token_exchange_endpoint` feature flag with the instance administrator.
 - **Wrong issuer/subject/audience:** stop; re-check `--hostname`, environment-token precedence, and `glab auth status --hostname <host>`.
 - **Duration rejected:** use a Go-style duration between `1s` and `12h`.
 - **Expired token:** request a new short-lived token; do not persist or attempt to refresh the old one.
+- **Stored-token error during Docker setup:** run `glab auth login --hostname <host>`; an environment-only token is not used by the helper.
+- **Credential-helper conflict:** inspect Docker's existing `credHelpers` entry and keep the current helper unless the operator explicitly approves a migration.
 
 See [references/commands.md](references/commands.md) for captured command help.

--- a/glab-artifact-registry/references/commands.md
+++ b/glab-artifact-registry/references/commands.md
@@ -1,13 +1,14 @@
 # glab artifact-registry command reference
 
-> Help captured from the checksum-verified glab v1.113.0 macOS arm64 release binary.
+> Help captured from the checksum-verified glab v1.114.0 macOS arm64 release binary. Terminal padding and trailing whitespace are removed. The binary renderer's `Gitlab` typo in three `--hostname` descriptions is normalized to the canonical `GitLab`; these blocks are therefore not claimed as byte-for-byte binary output.
 
 ## artifact-registry
 
 ```text
 
   Exchange a GitLab credential for a short-lived Artifact Registry access
-  token, either to check your access or to hand the token to a caller.
+  token, either to check your access, to hand the token to a caller, or to
+  configure a package manager to authenticate against the registry.
 
   This feature is an experiment and is not ready for production use.
   It might be unstable or removed at any time.
@@ -22,6 +23,7 @@
   COMMANDS
 
     get-token [--flags]  Get a short-lived access token for the GitLab Artifact Registry. (EXPERIMENTAL)
+    login [--flags]      Authenticate a package manager against the GitLab Artifact Registry. (EXPERIMENTAL)
     status [--flags]     Check your access to the GitLab Artifact Registry. (EXPERIMENTAL)
 
   FLAGS
@@ -29,6 +31,8 @@
     -h --help            Show help for this command.
 
 ```
+
+The `glab ar` alias emits the same help surface.
 
 ## artifact-registry get-token
 
@@ -72,6 +76,54 @@
     --hostname   GitLab hostname to request the token from. Defaults to the configured GitLab instance.
     --jq         Filter JSON output with a jq expression.
     -F --output  Format output as: text, json. (text)
+
+```
+
+## artifact-registry login
+
+```text
+
+  Configure a package manager to authenticate against the GitLab Artifact
+  Registry, using a short-lived access token exchanged from your GitLab
+  session.
+
+  With `--docker`, glab is registered as a Docker credential helper
+  for the registry, and Docker exchanges a fresh token on every pull or
+  push, so `--duration` does not apply.
+
+  Use `--registry` only for a registry the Artifact Registry
+  actually backs. The credential helper prefers the artifact registry
+  token and falls back to `container_registry_domains` only
+  when that exchange fails, so a container registry listed here gets an
+  artifact registry token it rejects on every pull.
+
+  Docker runs that credential helper as its own subprocess, which reads
+  your credentials from the configuration file and ignores
+  `GITLAB_TOKEN`. This command verifies the login the same way, so
+  run `glab auth login` first if no token is stored for the host.
+
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab artifact-registry login [--flags]
+
+  EXAMPLES
+
+    # Configure Docker to authenticate against a registry
+    glab artifact-registry login --docker --registry registry.example.com
+
+  FLAGS
+
+    --docker    Configure Docker to authenticate against the registry. Writes to $DOCKER_CONFIG, or ~/.docker when it is unset.
+    --duration  How long the exchanged token should remain valid. Ignored for now: --docker is the only tool this command configures, and its credential helper mints a fresh token for every request. (0s)
+    -h --help   Show help for this command.
+    --hostname  GitLab hostname to request the token from. Defaults to the configured GitLab instance.
+    --registry  Bare hostname of the registry to authenticate against.
 
 ```
 

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -63,6 +63,26 @@ glab config get https_proxy --host gitlab.mycompany.com
 
 **Precedence:** Per-host config overrides global config. Global config overrides the `HTTPS_PROXY` / `https_proxy` environment variables.
 
+## Dynamic custom headers for authenticating proxies
+
+For an authenticating proxy or access gateway, add a `custom_headers` list under the exact host entry in the global config. Each item must contain `name` and exactly one source: literal `value`, `valueFromEnv`, or `valueFromCommand`. Prefer `valueFromEnv` or a credential helper command so secrets are not stored directly in YAML.
+
+```yaml
+hosts:
+  gitlab.example.com:
+    custom_headers:
+      - name: X-Proxy-Client-ID
+        value: public-client-id
+      - name: X-Proxy-Client-Secret
+        valueFromEnv: PROXY_CLIENT_SECRET
+      - name: Proxy-Authorization
+        valueFromCommand: proxy-token-helper
+```
+
+Use `glab config edit --global` to edit the structured list; do not force it through a scalar `config set` call. A command source is split into an executable and arguments without an implicit shell, runs once per `glab` process with a 30-second timeout, and must print one non-empty line without NUL bytes. Its trimmed result is reused for all requests in that process, including OAuth refresh. If shell expansion is unavoidable, invoke a reviewed shell explicitly; otherwise prefer `valueFromEnv`.
+
+Treat custom header values as credentials. Keep literal secrets out of config, logs, command arguments, and repositories. Verify the host before enabling a header because `glab` attaches configured headers to requests for that host.
+
 ## Configuration file search order
 
 glab uses this global config selection:

--- a/glab-duo/SKILL.md
+++ b/glab-duo/SKILL.md
@@ -1,39 +1,13 @@
 ---
 name: glab-duo
-description: Interact with GitLab Duo AI assistant for code suggestions and chat. Use when accessing AI-powered code assistance, getting code suggestions, or chatting with GitLab Duo. Triggers on Duo, AI assistant, code suggestions, AI chat.
+description: Install and run GitLab Duo CLI through glab in interactive or headless mode. Use when accessing GitLab Duo Agent Platform from the terminal, running a bounded headless goal, or managing the wrapped Duo CLI binary. Triggers on Duo, GitLab Duo CLI, glab duo cli, AI assistant, headless goal, autonomous coding.
 ---
 
 # glab duo
 
 ## Overview
 
-```
-
-  Work with GitLab Duo, our AI-native assistant for the command line.
-
-  The GitLab Duo CLI integrates AI capabilities directly into your terminal
-  workflow. It helps you retrieve forgotten Git commands and offers guidance on
-  Git operations. You can accomplish specific tasks without switching contexts.
-
-  To interact with the GitLab Duo Agent Platform, use the
-  [GitLab Duo CLI](https://docs.gitlab.com/user/gitlab_duo_cli/).
-
-  A unified experience is proposed in
-  [epic 20826](https://gitlab.com/groups/gitlab-org/-/work_items/20826).
-
-  USAGE
-
-    glab duo <command> prompt [command] [--flags]
-
-  COMMANDS
-
-    ask <prompt> [--flags]  Generate Git commands from natural language.
-    cli [command]           Run the GitLab Duo CLI
-
-  FLAGS
-
-    -h --help               Show help for this command.
-```
+`glab duo` is centered on the GitLab Duo Agent Platform. The current visible command surface exposes `glab duo cli`; the legacy `glab duo ask` command is hidden and deprecated.
 
 ## Quick start
 
@@ -72,7 +46,23 @@ glab duo cli --update
 
 Use `--install` to download and install the GitLab Duo CLI binaries. Use `--yes` to skip confirmation prompts during installation, which is useful for automation and CI/CD pipelines.
 
-To persist prompt behavior, set `duo_cli_auto_download` and `duo_cli_auto_run` with `glab config set ... --global`. All unrecognized arguments and flags after `glab duo cli` pass through to the Duo CLI binary.
+### Interactive and headless modes
+
+```bash
+# Interactive, multi-prompt session with build and plan modes
+glab duo cli
+
+# One bounded prompt for a runner, script, or automated workflow
+glab duo cli run --goal "Fix the failing tests in this project"
+
+# Wrapper help versus the installed Duo CLI's own command surface
+glab duo cli --help
+glab duo cli help
+```
+
+Use headless `run --goal` only with a bounded task, an isolated working tree, explicit stop conditions, and an independent review of the resulting changes. `glab` passes unknown arguments and flags through to the Duo CLI binary, so verify the installed Duo CLI's own `help` before relying on forwarded options.
+
+To persist wrapper prompt behavior, set `duo_cli_auto_download` and `duo_cli_auto_run` with `glab config set ... --global`. `--yes` skips confirmation prompts for the current invocation.
 
 ### Important documentation note
 

--- a/glab-duo/references/commands.md
+++ b/glab-duo/references/commands.md
@@ -1,6 +1,8 @@
 # glab duo help
 
 > Complete affected help surfaces captured from the checksum-verified glab v1.114.0 macOS arm64 release binary, with only terminal padding and trailing whitespace removed.
+>
+> The `duo cli` capture was taken with no Duo CLI binary installed; its trailing `GITLAB DUO CLI` section is state-dependent and changes after installation.
 
 ## duo
 

--- a/glab-duo/references/commands.md
+++ b/glab-duo/references/commands.md
@@ -1,67 +1,128 @@
 # glab duo help
 
-> Help output captured from `glab duo --help`.
+> Complete affected help surfaces captured from the checksum-verified glab v1.114.0 macOS arm64 release binary, with only terminal padding and trailing whitespace removed.
+
+## duo
+
+```text
+
+  Use the GitLab Duo Agent Platform in your terminal. Ask GitLab Duo questions about your codebase and use it to
+  autonomously perform actions on your behalf.
+
+  `glab duo cli` installs and runs the GitLab Duo CLI (`duo`) binary. `glab` handles authentication, so you sign in only
+  once with `glab auth login`.
+
+  The GitLab Duo CLI requires GitLab 19.2 or later, or GitLab 18.11 to 19.1 with beta and experimental features turned
+  on. For all prerequisites and usage, see `glab duo cli --help`.
+
+
+  USAGE
+
+    glab duo [command] [--flags]
+
+  EXAMPLES
+
+    glab duo cli --install
+    glab duo cli
+    glab duo cli run --goal "Fix the failing tests in this project"
+
+  COMMANDS
+
+    cli [command] [--flags]  Run the GitLab Duo CLI.
+
+  FLAGS
+
+    -h --help                Show help for this command.
 
 ```
 
-  Work with GitLab Duo, our AI-native assistant for the command line.                                                   
-                                                                                                                        
-  GitLab Duo for the CLI integrates AI capabilities directly into your terminal                                         
-  workflow. It helps you retrieve forgotten Git commands and offers guidance on                                         
-  Git operations. You can accomplish specific tasks without switching contexts.                                         
-                                                                                                                        
-         
-  USAGE  
-         
-    glab duo <command> prompt [command] [--flags]  
-            
-  COMMANDS  
-            
-    ask <prompt> [--flags]  Generate Git commands from natural language.
-         
-  FLAGS  
-         
-    -h --help               Show help for this command.
-```
+## duo cli
 
-## duo ask
+```text
 
-```
+  Run the GitLab Duo CLI (`duo`) through `glab`.
 
-  Generate Git commands from natural language using AI assistance.                                                      
-                                                                                                                        
-  Describe what you want to do in plain language, and GitLab Duo suggests the                                           
-  appropriate Git commands. The AI provides both the commands and an explanation.                                       
-                                                                                                                        
-  After you receive the suggested commands, you can execute them directly from                                          
-  the CLI. You must confirm each command before it runs.                                                                
-                                                                                                                        
-  Use this command to:                                                                                                  
-                                                                                                                        
-  - Retrieve forgotten Git commands.                                                                                    
-  - Learn how to accomplish specific Git operations.                                                                    
-  - Get guidance on complex Git workflows.                                                                              
-  - Reduce context switching during development.                                                                        
-                                                                                                                        
-         
-  USAGE  
-         
-    glab duo ask <prompt> [--flags]                                                                                   
-            
-  EXAMPLES  
-            
-    $ glab duo ask list last 10 commit titles                                                                         
-    > A list of Git commands to show the titles of the latest 10 commits with an explanation and an option to execu…  
-                                                                                                                      
-    $ glab duo ask how do I undo my last commit                                                                       
-    > Suggestions for undoing the last commit with explanations of different approaches.                              
-                                                                                                                      
-    $ glab duo ask show me files changed in the last commit                                                           
-    > Commands to display files modified in the most recent commit.                                                   
-         
-  FLAGS  
-         
-    --git      Ask a question about Git. (true)
+  The GitLab Duo CLI brings the GitLab Duo Agent Platform to your terminal. Ask GitLab Duo questions about your codebase
+  and use it to autonomously perform actions on your behalf.
+
+  The GitLab Duo CLI runs in two modes:
+
+  - Interactive (default): `glab duo cli` opens a session for multiple prompts, with build and plan modes.
+  - Headless: `glab duo cli run --goal "<prompt>"` runs a single prompt and exits. For use in runners, scripts, and
+  automated workflows.
+
+  When you use the GitLab Duo CLI through `glab`, `glab` handles authentication for you. You authenticate only once.
+
+  Prerequisites:
+
+  - Use GitLab 19.2 or later.
+  - Run `glab auth login` to authenticate.
+  - Meet the prerequisites for GitLab Duo Agent Platform.
+  - Set a default GitLab Duo namespace, or run the command in a project that has GitLab Duo access.
+  - For GitLab Self-Managed and GitLab Dedicated on 19.2 or later, turn on GitLab Duo CLI access. It is on by default.
+
+  Note: If you are on GitLab 18.11 to 19.1, you can use the GitLab Duo CLI by turning on beta and experimental features.
+
+  Configuration options:
+
+  - `duo_cli_auto_run`: Skip the run confirmation prompt.
+  - `duo_cli_auto_download`: Skip the download confirmation prompt.
+
+  `glab` passes all other arguments and flags through to the GitLab Duo CLI binary. To see the GitLab Duo CLI commands
+  and flags, run `glab duo cli help`.
+
+  For more information, see the GitLab Duo CLI documentation.
+
+
+  USAGE
+
+    glab duo cli [command] [--flags]
+
+  EXAMPLES
+
+    # Start an interactive GitLab Duo CLI session
+    glab duo cli
+
+    # Use the GitLab Duo CLI in headless mode with a single prompt
+    glab duo cli run --goal "Fix the failing tests in this project"
+
+    # Pass any command or flag through to the GitLab Duo CLI binary (for example: model, version, run)
+    glab duo cli <command>
+    glab duo cli --model claude_sonnet_4_6
+
+    # Show GitLab CLI help content
+    glab duo cli --help
+
+    # Show GitLab Duo CLI help content, including commands and flags
+    glab duo cli help
+
+    # Run without prompts (for use in scripts and non-interactive environments)
+    glab duo cli --yes
+
+    # Install the GitLab Duo CLI binary
+    glab duo cli --install
+
+    # Install the GitLab Duo CLI binary without prompts
+    glab duo cli --install --yes
+
+    # Check for and install updates
+    glab duo cli --update
+
+  FLAGS
+
     -h --help  Show help for this command.
-```
+    --install  Install the GitLab Duo CLI binary without running it.
+    --update   Check for and install updates to the binary.
+    -y --yes   Skip confirmation prompts.
 
+GITLAB DUO CLI
+  The GitLab Duo CLI binary is not installed yet. To get started:
+
+    1. glab auth login          # authenticate, once
+    2. glab duo cli --install   # download the GitLab Duo CLI binary
+    3. glab duo cli             # start an interactive session
+
+  Or run 'glab duo cli' and follow the prompts.
+  After it is installed, 'glab duo cli help' shows the GitLab Duo CLI
+  commands and flags.
+```

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -416,6 +416,8 @@ glab mr view 123 --resolved
 
 Useful for quickly checking which review threads still need attention before merging.
 
+Normal text output from `glab mr view` now shows the source and target branches. Confirm the displayed `source → target` direction before reviewing, rebasing, or merging, especially for fork merge requests. Use `--output json` when automation needs stable branch fields rather than parsing the rendered line.
+
 ## `glab mr list` filtering flags
 
 `glab mr list` supports the following filtering and sorting flags:

--- a/glab-mr/references/commands.md
+++ b/glab-mr/references/commands.md
@@ -745,23 +745,36 @@ INHERITED FLAGS
 
 ## mr view
 
-```
+> Captured from the checksum-verified glab v1.114.0 macOS arm64 release binary, with only terminal padding and trailing whitespace removed.
 
-  Display the title, body, and other information about a merge request.
+```text
+
+  You can use a branch name or ID. Use `--web` to open in a browser.
+
 
   USAGE
 
-    glab mr view {<id> | <branch>} [--flags]
+    glab mr view [<id | branch>] [--flags]
+
+  EXAMPLES
+
+    glab mr view 123
+    glab mr view branch-name
+    glab mr view 123 --comments
+    glab mr view 123 --web
 
   FLAGS
 
     -c --comments     Show merge request comments and activities.
     -h --help         Show help for this command.
+    --jq              Filter JSON output with a jq expression.
     -F --output       Format output as: text, json. (text)
     -p --page         Page number.
     -P --per-page     Number of items to list per page. (20)
-    -R --repo         Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo         Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+    --resolved        Show only resolved discussions (implies --comments).
     -s --system-logs  Show system activities and logs.
+    --unresolved      Show only unresolved discussions (implies --comments).
     -w --web          Open merge request in a browser. Uses default browser or browser specified in BROWSER variable.
 ```
 

--- a/glab-variable/SKILL.md
+++ b/glab-variable/SKILL.md
@@ -59,6 +59,23 @@ glab variable import --input-file variables.json --skip-existing
 
 Import stops when a target variable already exists unless `--skip-existing` is set. Hidden variable values are omitted from exports, so those entries are skipped with a warning during import; recreate their values explicitly with `glab variable set --hidden` from an approved secret source. Treat export files as sensitive, keep them out of version control, and verify the target project or group before importing.
 
+## Masked and hidden group variables
+
+`glab variable set` now sends `--masked` and `--hidden` correctly for group-level variables. Use explicit flags, verify the target group, and never print the value during confirmation:
+
+```bash
+glab variable set DEPLOY_TOKEN "$DEPLOY_TOKEN" \
+  --group group/subgroup \
+  --masked \
+  --hidden \
+  --protected
+
+# Verify metadata without exposing the value
+glab variable get DEPLOY_TOKEN --group group/subgroup --output json
+```
+
+Masking and hiding are server-enforced properties, not substitutes for least privilege or rotation. If GitLab rejects a value because it does not satisfy masking rules, do not weaken the setting silently; fix the value format or get explicit operator approval for a different policy.
+
 ## Subcommands
 
 See [references/commands.md](references/commands.md) for full `--help` output.


### PR DESCRIPTION
## Upstream

- Version: **glab v1.114.0**
- Canonical release: https://gitlab.com/gitlab-org/cli/-/releases/v1.114.0
- Canonical latest-release API: https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest
- Upstream commit: `4d7c6cda781ab2922c6f207d50cf744461c0e965`

## CLI changes evaluated

- Added experimental `glab artifact-registry login --docker` and Docker credential-helper integration.
- Added dynamic per-host custom HTTP headers sourced from a literal, environment variable, or bounded helper command.
- Reworked `glab duo` help around interactive and headless GitLab Duo CLI usage.
- `glab mr view` text output now includes source and target branches.
- Fixed masked/hidden group-variable writes, same-host SSH account resolution, config secret/error handling, and related behavior.

## Generated skill/package changes

- Added safe Docker credential-helper setup and troubleshooting to `glab-artifact-registry`.
- Updated `glab-duo` for interactive and headless `run --goal` workflows.
- Added dynamic proxy-header guidance to `glab-config`.
- Documented MR branch-direction rendering and corrected group-variable masking behavior.
- Re-captured the complete affected Artifact Registry, Duo, and MR-view help surfaces from the verified release binary.
- Bumped skills package metadata to `1.13.24` in `VERSION` only after reconciling the already-published v1.13.23 runner correction.

## Validation

- Verified official macOS arm64 artifact SHA-256 against GitLab's published `checksums.txt`: `d60d76cc0176cd7e7efe9c9fae0e57979048dad78fdd24903ba986ded1c82a01`.
- Verified binary: `glab 1.114.0 (4d7c6cda7)`.
- Compared 7 stored glab help fences line-for-line after trailing-whitespace normalization; normalized only Fang's `Gitlab` typo to canonical `GitLab`, as documented in the reference/version metadata.
- Validated all 48 skill frontmatters; `npx skills add . --list` discovered all 48 skills.
- Selective-copy install smoke passed for all five changed skills, including referenced command files.
- `bash scripts/build-claude-skill.sh` merged 47 sub-skills plus the orchestrator (5,949 lines / 200,971 bytes); `unzip -t` passed and changed guidance is present in the merged artifact.
- Bash syntax passed for all 18 repository shell scripts; Markdown fences and changed relative links passed; `git diff --check` passed.

## Review request

Vince, please review the command semantics, security guidance, and deliberate `Gitlab` → `GitLab` help normalization. This PR will not be merged automatically.
