### PR TITLE
feat: refresh glab skills for v1.115.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,13 @@
-1.13.24
+1.13.25
 
 Release/version change metadata for this skill set lives here, not in individual skill files.
 
 Historical notes consolidated from skill docs:
+- v1.13.25
+  - glab v1.115.0 refresh: documented Artifact Registry login paths for Docker, Maven, Gradle, npm, and sbt; added `glab config path`; and refreshed affected exact-help captures from the verified macOS arm64 binary.
+  - Documented `--description-file` for issue create/update, MR create/update, and work-items create/update, including stdin support and conflicts with inline descriptions and create templates.
+  - Updated Dependency Firewall as experimental with the currently exposed `ci-summary` command, and updated Orbit guidance for `glab orbit` routing through the managed `orbit-cli` binary.
+  - Reviewed authentication, config, CI, glrepo, and MR merge fixes; added operational notes where they affect troubleshooting or output expectations.
 - v1.13.24
   - glab v1.114.0 refresh: added experimental `artifact-registry login --docker` guidance and checksum-verified help, including stored-token requirements, Docker config targeting, registry classification, helper conflicts, and fresh per-request token exchange.
   - Updated Duo CLI guidance and complete help for interactive and headless `run --goal` modes, wrapper versus installed-binary help, prerequisites, and bounded-agent safety.

--- a/glab-artifact-registry/SKILL.md
+++ b/glab-artifact-registry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-artifact-registry
-description: Exchange GitLab credentials for short-lived Artifact Registry tokens, verify token identity, and configure Docker's credential helper with glab. Use when checking GitLab Artifact Registry access, obtaining an ephemeral registry token, or configuring Docker for a GitLab Artifact Registry. Triggers on artifact registry, glab artifact-registry, glab ar, get-token, token exchange, registry access status, artifact-registry login, Docker credential helper.
+description: Exchange GitLab credentials for short-lived Artifact Registry tokens, verify token identity, and configure package-manager authentication with glab. Use when checking GitLab Artifact Registry access, obtaining an ephemeral registry token, or configuring Docker, Maven, Gradle, npm, or sbt for a GitLab Artifact Registry. Triggers on artifact registry, glab artifact-registry, glab ar, get-token, token exchange, registry access status, artifact-registry login, Docker credential helper, Maven registry, Gradle registry, npm auth, sbt credentials.
 ---
 
 # glab artifact-registry
@@ -53,9 +53,15 @@ unset artifact_token
 
 Use `--output json` only when a consumer also needs the expiry. Treat the JSON document as secret because it contains the token. Do not pass `--jq` expressions that print the token into logs.
 
-## Configure Docker credential exchange
+## Configure package-manager authentication
 
-`glab artifact-registry login --docker` installs the `docker-credential-glab` shim and registers `glab` under Docker's per-registry `credHelpers`. Docker then exchanges a fresh short-lived token for every pull or push, so `--duration` is currently ignored.
+`glab artifact-registry login` configures exactly one package manager per run:
+
+- `--docker` installs the `docker-credential-glab` shim and registers `glab` under Docker's per-registry `credHelpers`.
+- `--maven` writes a `<server>` block to `~/.m2/settings.xml`, keyed by `--registry-alias`; the consuming `<repository>` must use the same `<id>`.
+- `--gradle` writes `{alias}Url`, `{alias}Username`, and `{alias}Password` to `~/.gradle/gradle.properties`, where `{alias}` is `--registry-alias`.
+- `--npm` writes a `//{host}{path}/:_authToken` entry to `~/.npmrc`; you must still configure `registry=` or `@scope:registry=` to point npm at the registry.
+- `--sbt` writes a `credentials +=` line to `~/.sbt/1.0/credentials.sbt`; sbt installs with a custom global base may not read that file.
 
 ```bash
 # Inspect the intended Docker config and stored GitLab identity first
@@ -67,15 +73,25 @@ glab artifact-registry login \
   --hostname gitlab.example.com \
   --docker \
   --registry registry.example.com
+
+# Configure Maven for a two-hour token
+glab artifact-registry login \
+  --hostname gitlab.example.com \
+  --maven \
+  --registry https://ar.example.com \
+  --registry-alias gitlab-ar \
+  --duration 2h
 ```
 
 Safety and compatibility rules:
 
-- `--registry` must be a bare hostname, optionally with a port. Do not pass a URL or path.
-- The helper subprocess intentionally ignores `GITLAB_TOKEN`. It normally reads a token stored by `glab auth login`; inside a GitLab CI job, it also honors `CI_JOB_TOKEN` when CI auto-login is enabled with `GLAB_ENABLE_CI_AUTOLOGIN=true`. Outside that CI path, store authentication for the selected host before configuring Docker.
+- For `--docker`, `--registry` must be a bare hostname, optionally with a port. For Maven, Gradle, npm, and sbt, `--registry` is typically a URL.
+- Docker exchanges a fresh token for every pull or push, so `--duration` does not apply. Maven, Gradle, npm, and sbt receive one static token; rerun the command before `--duration` elapses.
+- The Docker helper subprocess intentionally ignores `GITLAB_TOKEN`. It normally reads a token stored by `glab auth login`; inside a GitLab CI job, it also honors `CI_JOB_TOKEN` when CI auto-login is enabled with `GLAB_ENABLE_CI_AUTOLOGIN=true`. Maven, Gradle, npm, and sbt login paths can read `GITLAB_TOKEN` because `glab` writes the exchanged token into each tool's config file.
 - Use this only for a registry actually backed by GitLab Artifact Registry. Misclassifying a normal container registry can make every pull fail because an exchanged Artifact Registry token takes precedence.
-- The command writes `${DOCKER_CONFIG:-$HOME/.docker}/config.json`. Review that file's location first. It refuses to replace another per-registry credential helper, preserves existing `docker login` data, and reports when the new helper shadows that data.
-- Re-running the command for the same registry is safe and idempotent. After configuration, test a non-destructive pull or registry operation against the intended host without printing credentials.
+- Review the destination config path before writing: `${DOCKER_CONFIG:-$HOME/.docker}/config.json`, `~/.m2/settings.xml`, `~/.gradle/gradle.properties`, `~/.npmrc`, or `~/.sbt/1.0/credentials.sbt`.
+- `--registry-alias` applies only to Maven and Gradle. For Gradle, choose an alias that is a valid identifier in the build script; the derived default can contain hyphens.
+- Re-running the command for the same registry refreshes or replaces the matching entry. After configuration, test a non-destructive package-manager operation against the intended host without printing credentials.
 
 ## Troubleshooting
 
@@ -83,7 +99,8 @@ Safety and compatibility rules:
 - **Wrong issuer/subject/audience:** stop; re-check `--hostname`, environment-token precedence, and `glab auth status --hostname <host>`.
 - **Duration rejected:** use a Go-style duration between `1s` and `12h`.
 - **Expired token:** request a new short-lived token; do not persist or attempt to refresh the old one.
-- **Stored-token error during Docker setup:** run `glab auth login --hostname <host>`; an environment-only token is not used by the helper.
+- **Stored-token error during Docker setup:** run `glab auth login --hostname <host>`; an environment-only token is not used by the Docker helper.
 - **Credential-helper conflict:** inspect Docker's existing `credHelpers` entry and keep the current helper unless the operator explicitly approves a migration.
+- **Build tool still unauthenticated:** verify the tool reads the file that `glab artifact-registry login` wrote, and that its registry URL or repository ID matches the written key.
 
 See [references/commands.md](references/commands.md) for captured command help.

--- a/glab-artifact-registry/references/commands.md
+++ b/glab-artifact-registry/references/commands.md
@@ -1,6 +1,6 @@
 # glab artifact-registry command reference
 
-> Help captured from the checksum-verified glab v1.114.0 macOS arm64 release binary. Terminal padding and trailing whitespace are removed. The binary renderer's `Gitlab` typo in three `--hostname` descriptions is normalized to the canonical `GitLab`; these blocks are therefore not claimed as byte-for-byte binary output.
+> Help captured from the checksum-verified glab v1.115.0 macOS arm64 release binary. Terminal padding and trailing whitespace are removed. The binary renderer's `Gitlab` typo in `--hostname` descriptions is normalized to the canonical `GitLab`; these blocks are therefore not claimed as byte-for-byte binary output.
 
 ## artifact-registry
 
@@ -87,20 +87,58 @@ The `glab ar` alias emits the same help surface.
   Registry, using a short-lived access token exchanged from your GitLab
   session.
 
-  With `--docker`, glab is registered as a Docker credential helper
-  for the registry, and Docker exchanges a fresh token on every pull or
-  push, so `--duration` does not apply.
+  Use the flag for your package manager:
 
-  Use `--registry` only for a registry the Artifact Registry
-  actually backs. The credential helper prefers the artifact registry
-  token and falls back to `container_registry_domains` only
-  when that exchange fails, so a container registry listed here gets an
-  artifact registry token it rejects on every pull.
+  - `--docker`: registers `glab` as a Docker credential
+    helper for the registry.
+  - `--maven`: writes a `<server>` block in
+    `~/.m2/settings.xml`, keyed by `--registry-alias`.
+    Reference it from a `<repository>` carrying the same
+    `<id>`.
+  - `--gradle`: writes `{alias}Url`,
+    `{alias}Username`, and `{alias}Password` in
+    `~/.gradle/gradle.properties`, where `{alias}` is
+    `--registry-alias`.
+  - `--npm`: writes a `//{host}{path}/:_authToken` entry
+    in `~/.npmrc`. You still need to point npm at the registry, with a
+    `registry=` or `@scope:registry=` line.
+  - `--sbt`: writes a `credentials +=` line in
+    `~/.sbt/1.0/credentials.sbt`, which assumes a stock sbt 1.x.
+    An sbt that moved its global base, with
+    `-Dsbt.global.base` or a newer default, does not read that
+    file.
 
-  Docker runs that credential helper as its own subprocess, which reads
-  your credentials from the configuration file and ignores
-  `GITLAB_TOKEN`. This command verifies the login the same way, so
-  run `glab auth login` first if no token is stored for the host.
+  Token lifetime:
+
+  - `--docker` exchanges a fresh token on every pull or push,
+    so `--duration` does not apply.
+  - Every other flag writes one token, and nothing refreshes it. Run
+    the command again before `--duration` elapses. The default
+    is 15 minutes and the maximum is 12 hours.
+
+  Credential resolution:
+
+  - Docker runs the credential helper as its own subprocess, which
+    reads your credentials from the configuration file and ignores
+    `GITLAB_TOKEN`. This command verifies the login the same
+    way, so run `glab auth login` first if no token is stored
+    for the host.
+  - Every other flag does read `GITLAB_TOKEN`. `glab`
+    writes the token into each file itself, so the tool can read it
+    without fetching credentials itself.
+
+  Registry and alias selection:
+
+  - Use `--registry` only for a registry the Artifact Registry
+    actually backs. If you name a container registry here, it receives the
+    wrong token and the error only surfaces on the next pull.
+  - `--registry-alias` applies to `--maven` and
+    `--gradle` only, because `--npm` and
+    `--sbt` key their entries on `--registry` itself.
+    For `--gradle`, use an alias that is a valid identifier
+    in your build script: the default is derived from the registry
+    host and contains hyphens, which Groovy cannot interpolate as
+    `${...}`.
 
   This feature is an experiment and is not ready for production use.
   It might be unstable or removed at any time.
@@ -117,13 +155,30 @@ The `glab ar` alias emits the same help surface.
     # Configure Docker to authenticate against a registry
     glab artifact-registry login --docker --registry registry.example.com
 
+    # Configure Maven to authenticate against a registry for two hours
+    glab artifact-registry login --maven --registry https://ar.example.com --duration 2h
+
+    # Configure Gradle to authenticate against a registry for two hours
+    glab artifact-registry login --gradle --registry https://ar.example.com --duration 2h
+
+    # Configure npm to authenticate against a registry for two hours
+    glab artifact-registry login --npm --registry https://ar.example.com --duration 2h
+
+    # Configure sbt to authenticate against a registry for two hours
+    glab artifact-registry login --sbt --registry https://ar.example.com --duration 2h
+
   FLAGS
 
-    --docker    Configure Docker to authenticate against the registry. Writes to $DOCKER_CONFIG, or ~/.docker when it is unset.
-    --duration  How long the exchanged token should remain valid. Ignored for now: --docker is the only tool this command configures, and its credential helper mints a fresh token for every request. (0s)
-    -h --help   Show help for this command.
-    --hostname  GitLab hostname to request the token from. Defaults to the configured GitLab instance.
-    --registry  Bare hostname of the registry to authenticate against.
+    --docker          Configure Docker to authenticate against the registry. Writes to $DOCKER_CONFIG, or ~/.docker when it is unset.
+    --duration        How long the exchanged token should remain valid. Ignored for --docker. (15m0s)
+    --gradle          Configure Gradle to authenticate against the registry. Writes to ~/.gradle/gradle.properties.
+    -h --help         Show help for this command.
+    --hostname        GitLab hostname to request the token from. Defaults to the configured GitLab instance.
+    --maven           Configure Maven to authenticate against the registry. Writes to ~/.m2/settings.xml.
+    --npm             Configure npm to authenticate against the registry. Writes to ~/.npmrc.
+    --registry        Registry to authenticate against. For --docker, a bare hostname; for others, typically a URL.
+    --registry-alias  Alias/Id to register the registry under (Maven/Gradle only). Defaults to a name derived from --registry.
+    --sbt             Configure sbt to authenticate against the registry. Writes to ~/.sbt/1.0/credentials.sbt.
 
 ```
 

--- a/glab-auth/SKILL.md
+++ b/glab-auth/SKILL.md
@@ -72,6 +72,10 @@ Use `--insecure-storage` only when plaintext config-file storage is explicitly r
 
 If a keyring is locked, unavailable, or denies access, glab reports the credential-read failure directly. Fix keyring access or re-authenticate instead of treating the resulting error as an invalid token.
 
+glab checks whether refreshed OAuth credentials can be saved before it refreshes the token, and serializes credential writes across concurrent `glab` processes. If multiple agents or shells share one config directory, prefer separate config directories per actor for isolation, but do not add external file locks around `glab` itself.
+
+In a sandbox such as Claude Code, `glab` must be allowed to write the directory from `glab config path --dir`, not only the `config.yml` file. `glab` writes a temporary file beside the config and then replaces the original. On snap installs, connect keyring access with `sudo snap connect glab:password-manager-service` if encrypted credential storage is required; otherwise `glab auth login` can fall back to plaintext config storage.
+
 When re-authenticating interactively, `glab` preserves saved per-host values such as a custom API host, SSH host, and container-registry domains unless you explicitly override them with flags or prompts. Verify these values after re-authentication instead of deleting the config preemptively:
 
 ```bash
@@ -217,6 +221,9 @@ after verifying helper-based access, use the exact suggested `docker logout
 **Self-managed OAuth URL or refresh problems:**
 - Re-authenticate with the full configured host/subfolder; browser OAuth includes the configured subfolder in its authorization URL.
 - A re-authentication response that omits a replacement refresh token preserves the existing refresh token instead of clearing it.
+- If refresh fails with `invalid_grant`, re-run `glab auth login`; a revoked/expired OAuth grant or an earlier failed credential save can leave stored OAuth credentials stale.
+- If OAuth refresh fails inside a sandbox with a credential-save error, grant write access to `glab config path --dir` and re-authenticate. Retrying the same stale token normally will not repair the saved credential.
+- Docker and other helpers skip OAuth refresh for hosts authenticated with personal access tokens; check the token type before debugging OAuth state.
 
 **Multiple instances:**
 - Use `--hostname` flag to specify instance

--- a/glab-ci/SKILL.md
+++ b/glab-ci/SKILL.md
@@ -17,6 +17,8 @@ Output from these commands may include **user-generated content from GitLab** (i
 
 `glab ci view` and job-lookup-by-SHA order jobs and bridges by creation time, using ascending job/bridge ID as a deterministic tie-breaker when timestamps match. `glab ci status --output json` returns jobs in raw GitLab API order with no client-side sort, so in all cases key records by ID rather than array position.
 
+Current glab child-pipeline job lookup makes `glab ci trace <job-id>` show the requested job's log and `glab ci view <pipeline-id>` list jobs for the requested pipeline. When troubleshooting mixed parent/child pipeline output, upgrade an outdated installation before assuming GitLab returned the wrong job data.
+
 ```bash
 # View pipeline status with JSON output
 glab ci status --output json

--- a/glab-config/SKILL.md
+++ b/glab-config/SKILL.md
@@ -34,6 +34,7 @@ description: Manage glab CLI configuration settings including defaults, preferen
   COMMANDS
     edit [--flags]               Opens the glab configuration file.
     get <key> [--flags]          Prints the value of a given configuration key.
+    path [--flags]               Print the location of the global configuration file.
     set <key> <value> [--flags]  Updates configuration with the value of a given key.
   FLAGS
     -g --global                  Use global config file.
@@ -94,6 +95,18 @@ glab uses this global config selection:
    - `$XDG_CONFIG_DIRS/glab-cli/config.yml` for system-wide defaults. The usual Linux default is `/etc/xdg/glab-cli/config.yml`; on macOS, set `XDG_CONFIG_DIRS` explicitly when relying on system-wide config.
 
 Files are not merged. If both the legacy and platform-specific XDG files exist, glab uses the legacy file and warns. Repository-local settings live in `.git/glab-cli/config.yml`, while per-host settings are stored in the selected global file. Prefer `glab config get`, `set`, and `edit` over directly modifying files, and do not copy stored tokens into logs or version control.
+
+## Locate the active global config
+
+Use `glab config path` instead of hard-coding the global config file location. It prints the path even when the file does not exist yet; `--dir` prints the parent directory.
+
+```bash
+glab config path
+glab config path --dir
+$EDITOR "$(glab config path)"
+```
+
+When a sandboxed tool needs permission to let `glab` refresh or rewrite credentials, grant write access to the directory from `glab config path --dir`, not just the `config.yml` file. `glab` writes a temporary file in that directory and then replaces the config file.
 
 ## Env-first agent pattern
 

--- a/glab-config/references/commands.md
+++ b/glab-config/references/commands.md
@@ -1,136 +1,200 @@
 # glab config help
 
-> Help output captured from `glab config --help`.
+> Help output captured from the checksum-verified glab v1.115.0 macOS arm64 release binary. Terminal padding and trailing whitespace are removed.
 
-```
+## config
 
-  Manage key/value strings.                                                                                             
-                                                                                                                        
-  Current respected settings:                                                                                           
-                                                                                                                        
-  - branch_prefix: Prefix used by glab stack when naming generated branches. Defaults to the current user's username (from os/user.Current), then glab-stack if unavailable.
-  - browser: If unset, uses the default browser. Override with $BROWSER.
-  - check_update: Notify about new glab versions. Defaults to true. Override with $GLAB_CHECK_UPDATE.
-  - display_hyperlinks: Enable terminal hyperlinks. Defaults to true. Override with $FORCE_HYPERLINKS.
-  - duo_cli_auto_download: Automatically download Duo CLI without prompting.
-  - duo_cli_auto_run: Automatically run Duo CLI without prompting.
-  - editor: If unset, uses the default editor. Override with $EDITOR.
-  - git_protocol: Git protocol. Supported values: ssh, https. Defaults to ssh.
-  - glab_pager: Pager command, such as less -R.
-  - glamour_style: Markdown renderer style: dark, light, notty, or a custom glamour style.
-  - host: If unset, defaults to https://gitlab.com.
-  - no_prompt: If true, disables interactive prompts. Defaults to false. Override with $NO_PROMPT.
-  - notify_skill_updates: Show installed agent-skill update notices. Defaults to true. Override with $GLAB_NOTIFY_SKILL_UPDATES.
-  - orbit_local_auto_download: Automatically download Orbit local CLI without prompting.
-  - orbit_local_auto_run: Automatically run Orbit local CLI without prompting.
-  - remote_alias: Preferred Git remote name when multiple remotes exist.
-  - show_whats_new: Show the one-time post-upgrade glab whatsnew banner. Defaults to true. Override with $GLAB_SHOW_WHATS_NEW.
-  - telemetry: Send usage data to the GitLab instance. Defaults to true. Override with $GLAB_SEND_TELEMETRY.
-  - token: GitLab access token. Defaults to environment variables.
-  - visual: Takes precedence over editor. Override with $VISUAL.
-                                                                                                                        
-         
-  USAGE  
-         
-    glab config [command] [--flags]  
-            
-  COMMANDS  
-            
+```text
+
+  Manage key/value strings.
+
+  Current respected settings:
+
+  - `branch_prefix`: Prefix used by `glab stack` when naming generated branches. Defaults to the current user's username
+  (from `os/user.Current`), falling back to `glab-stack` if unavailable.
+  - `browser`: If unset, uses the default browser. Override with environment variable `$BROWSER`.
+  - `check_update`: If true, notifies of new versions of glab. Defaults to `true`. Override with environment variable
+  `$GLAB_CHECK_UPDATE`.
+  - `display_hyperlinks`: If `false`, disables hyperlinks in terminal output. Defaults to `true`. Override with
+  environment variable `$FORCE_HYPERLINKS`.
+  - `duo_cli_auto_download`: If `true`, automatically downloads the Duo CLI binary without prompting.
+  - `duo_cli_auto_run`: If `true`, automatically runs GitLab Duo CLI without prompting.
+  - `editor`: If unset, uses the default editor. Override with environment variable `$EDITOR`.
+  - `git_protocol`: Protocol used for Git operations. Supported values: `ssh`, `https`. Defaults to `ssh`.
+  - `glab_pager`: Your desired pager command to use, such as `less -R`.
+  - `glamour_style`: Your desired Markdown renderer style. Options are dark, light, notty. Custom styles are available
+  using glamour.
+  - `host`: If unset, defaults to `https://gitlab.com`.
+  - `no_prompt`: If `true`, disables interactive prompts. Defaults to `false`. Override with environment variable
+  `$NO_PROMPT`.
+  - `notify_skill_updates`: If `true`, shows a notice when an installed agent skill has updates available. Defaults to
+  `true`. Override with environment variable `$GLAB_NOTIFY_SKILL_UPDATES`.
+  - `orbit_local_auto_download`: If `true`, automatically downloads the Orbit local CLI binary without prompting.
+  - `orbit_local_auto_run`: If `true`, automatically runs Orbit local CLI without prompting.
+  - `remote_alias`: Name of the `git remote` that points at the GitLab repository. Used to resolve which remote to
+  operate against when multiple are configured.
+  - `show_whats_new`: If true, shows a one-time post-upgrade banner pointing at `glab whatsnew` when a new version is
+  detected. Defaults to `true`. Override with environment variable `$GLAB_SHOW_WHATS_NEW`.
+  - `telemetry`: If `false`, disables sending usage data to your GitLab instance. Defaults to `true`. Override with
+  environment variable `$GLAB_SEND_TELEMETRY`.
+  - `token`: Your GitLab access token. Defaults to environment variables.
+  - `visual`: Takes precedence over `editor`. If unset, uses the default editor. Override with environment variable
+  `$VISUAL`.
+
+  Configuration file locations follow the XDG Base Directory specification.
+  For the full search order and platform-specific paths, see configuration.
+
+
+  USAGE
+
+    glab config [command] [--flags]
+
+  COMMANDS
+
     edit [--flags]               Opens the glab configuration file.
     get <key> [--flags]          Prints the value of a given configuration key.
+    path [--flags]               Print the location of the global configuration file.
     set <key> <value> [--flags]  Updates configuration with the value of a given key.
-         
-  FLAGS  
-         
+
+  FLAGS
+
     -g --global                  Use global config file.
     -h --help                    Show help for this command.
+
 ```
 
 ## config edit
 
-```
+```text
 
-  Opens the glab configuration file.                                                                                    
-  The command uses the following order when choosing the editor to use:                                                 
-                                                                                                                        
-  1. 'glab_editor' field in the configuration file                                                                      
-  2. 'VISUAL' environment variable                                                                                      
-  3. 'EDITOR' environment variable                                                                                      
-                                                                                                                        
-         
-  USAGE  
-         
-    glab config edit [--flags]                                        
-            
-  EXAMPLES  
-            
-    Open the configuration file with the default editor               
-    - glab config edit                                                
-                                                                      
-    Open the configuration file with vim                              
-    - EDITOR=vim glab config edit                                     
-                                                                      
-    Set vim to be used for all future 'glab config edit' invocations  
-    - glab config set editor vim                                      
-    - glab config edit                                                
-                                                                      
-    Open the local configuration file with the default editor         
-    - glab config edit -l                                             
-         
-  FLAGS  
-         
+  The command uses the following order when choosing the editor to use:
+
+  1. `glab_editor` field in the configuration file.
+  1. `VISUAL` environment variable.
+  1. `EDITOR` environment variable.
+
+
+  USAGE
+
+    glab config edit [--flags]
+
+  EXAMPLES
+
+    # Open the configuration file with the default editor
+    glab config edit
+
+    # Open the configuration file with vim
+    EDITOR=vim glab config edit
+
+    # Set vim to be used for all future 'glab config edit' invocations
+    glab config set editor vim
+    glab config edit
+
+    # Open the local configuration file with the default editor
+    glab config edit -l
+
+  FLAGS
+
     -h --help   Show help for this command.
     -l --local  Open '.git/glab-cli/config.yml' file instead of the global '~/.config/glab-cli/config.yml' file.
+
 ```
 
 ## config get
 
-```
+```text
 
-  Prints the value of a given configuration key.                                                                        
-         
-  USAGE  
-         
-    glab config get <key> [--flags]  
-            
-  EXAMPLES  
-            
-    $ glab config get editor         
-    > vim                            
-                                     
-    $ glab config get glamour_style  
-    > notty                          
-         
-  FLAGS  
-         
+  By default, the lookup order is: environment variables, then the local
+  repository configuration, then the global configuration. Use `--global` to
+  read only from the global configuration file, or `--host` to read a
+  per-host setting.
+
+  If the key is not set, nothing is printed.
+
+
+  USAGE
+
+    glab config get <key> [--flags]
+
+  EXAMPLES
+
+    $ glab config get editor
+    vim
+
+    $ glab config get glamour_style
+    notty
+
+  FLAGS
+
     -g --global  Read from global config file (~/.config/glab-cli/config.yml). (default checks 'Environment variables → Local → Global')
     -h --help    Show help for this command.
     --host       Get per-host setting.
+
+```
+
+## config path
+
+```text
+
+  Print where `glab` reads and writes its global configuration. The location depends on the platform and whether a
+  legacy configuration directory exists, so use this command instead of hard-coding a path.
+
+  The command prints the path even if the file does not exist yet, so it is safe to run before the first `glab auth
+  login`.
+
+  Use `--dir` to print the parent directory. Grant write access to that directory rather than to `config.yml` alone,
+  because `glab` writes a temporary file in that directory first and then replaces `config.yml` with it.
+
+  Repository-local settings live in the repository's `.git/glab-cli/config.yml` and this command does not report them.
+
+  If no user configuration file exists, `glab` falls back to a read-only system-wide one. This command always reports
+  the user location.
+
+
+  USAGE
+
+    glab config path [--flags]
+
+  EXAMPLES
+
+    # Print the path to the global configuration file
+    glab config path
+
+    # Print the directory that holds the configuration file
+    glab config path --dir
+
+    # Open the configuration file in an editor
+    $EDITOR "$(glab config path)"
+
+  FLAGS
+
+    --dir      Print the configuration directory instead of the configuration file.
+    -h --help  Show help for this command.
+
 ```
 
 ## config set
 
-```
+```text
 
-  Update the configuration by setting a key to a value.                                                                 
-  Use 'glab config set --global' to set a global config.                                                                
-  Specifying the '--host' flag also saves in the global configuration file.                                             
-                                                                                                                        
-         
-  USAGE  
-         
-    glab config set <key> <value> [--flags]          
-            
-  EXAMPLES  
-            
-    - glab config set editor vim                     
-    - glab config set token xxxxx --host gitlab.com  
-    - glab config set check_update false --global    
-         
-  FLAGS  
-         
+  Use `glab config set --global` to write to the global configuration.
+  Specifying the `--host` flag also saves to the global configuration file.
+
+
+  USAGE
+
+    glab config set <key> <value> [--flags]
+
+  EXAMPLES
+
+    glab config set editor vim
+    glab config set token xxxxx --host gitlab.com
+    glab config set check_update false --global
+
+  FLAGS
+
     -g --global  Write to global '~/.config/glab-cli/config.yml' file rather than the repository's '.git/glab-cli/config.yml' file.
     -h --help    Show help for this command.
     --host       Set per-host setting.
-```
 
+```

--- a/glab-dependency-firewall/SKILL.md
+++ b/glab-dependency-firewall/SKILL.md
@@ -1,52 +1,18 @@
 ---
 name: glab-dependency-firewall
-description: Configure and inspect GitLab Dependency Firewall for local package-manager workflows with glab. Use when setting npm resolve/deploy registry URLs, reviewing .gitlab/df/config.json, summarizing blocked or flagged packages from CI logs, or troubleshooting Dependency Firewall exit codes. Triggers on dependency firewall, glab df, glab dependency-firewall, npm registry policy, ci-summary, blocked package.
+description: Inspect GitLab Dependency Firewall activity from local package-manager workflows with glab. Use when summarizing blocked or flagged packages from CI logs, reviewing .gitlab/df/ci-log.json, or troubleshooting Dependency Firewall exit codes. Triggers on dependency firewall, glab df, glab dependency-firewall, npm registry policy, ci-summary, blocked package, flagged package.
 ---
 
 # glab dependency-firewall
 
-Configure and monitor GitLab Dependency Firewall for local package managers. The command group is beta; verify live help before relying on it in long-lived automation.
+Inspect GitLab Dependency Firewall activity for local package-manager workflows. The current command group is marked experimental, and the verified release binary exposes `ci-summary` only; do not rely on older `configure` examples unless live help on the target machine still lists them.
 
 ## Quick start
 
 ```bash
-# Configure both npm registry paths from the package-manager working directory
-glab dependency-firewall configure npm \
-  --repo-resolve https://gitlab.com/api/v4/projects/42/packages/npm/ \
-  --repo-deploy https://gitlab.com/api/v4/projects/42/packages/npm/
-
-# Preserve the existing deploy URL and update only the resolve URL
-glab df configure npm \
-  --repo-resolve https://gitlab.com/api/v4/projects/42/packages/npm/
-
 # Summarize the current working directory's Dependency Firewall CI log
 glab dependency-firewall ci-summary
 ```
-
-## Configure npm registry URLs
-
-`configure` currently supports `npm`. It writes `.gitlab/df/config.json` relative to the current working directory, so run it from the same directory where npm will run. Only explicitly supplied values are changed; omitted values, other package-manager blocks, and unknown keys are preserved.
-
-Before writing:
-
-1. Confirm the intended project/package registry URLs.
-2. Run from the package-manager working directory.
-3. Do not embed access tokens or other credentials in registry URLs.
-4. Review the resulting config diff before committing it.
-
-```bash
-# Resolve/install only
-glab dependency-firewall configure npm \
-  --repo-resolve https://gitlab.example.com/api/v4/projects/42/packages/npm/
-
-# Publish/deploy only; existing resolve configuration is preserved
-glab dependency-firewall configure npm \
-  --repo-deploy https://gitlab.example.com/api/v4/projects/42/packages/npm/
-
-git diff -- .gitlab/df/config.json
-```
-
-At least one of `--repo-resolve` or `--repo-deploy` is required. The command does not accept `--repo`; its configuration is local to the current working directory.
 
 ## Summarize CI activity
 
@@ -80,13 +46,13 @@ Treat exit `3` as a policy result, not a transient command failure. Surface the 
 - Confirm `.gitlab/df/ci-log.json` exists under the current working directory used for the command.
 - Do not assume a log in a repository root applies when the package manager ran in a nested workspace.
 
-**Config changed the wrong checkout:**
-- Revert the unintended `.gitlab/df/config.json` change.
-- Change to the package-manager working directory and rerun with the verified URL.
+**A `configure` example fails:**
+- `glab dependency-firewall configure` is not exposed by the verified current release binary.
+- Re-check `glab dependency-firewall --help` on the target machine before using older docs or scripts.
 
 **Unsupported package manager:**
-- The current command surface supports `npm` only.
-- Do not invent configuration for another manager; check a newer `glab dependency-firewall configure --help` or official docs.
+- The current visible command surface does not configure package managers.
+- Do not invent configuration for another manager; check live help or official docs for the target glab/GitLab version.
 
 ## Command reference
 

--- a/glab-dependency-firewall/references/commands.md
+++ b/glab-dependency-firewall/references/commands.md
@@ -1,20 +1,19 @@
 # glab dependency-firewall command reference
 
-Source: <https://docs.gitlab.com/cli/dependency-firewall/>
-
-> Help output captured from the checksum-verified release binary.
+> Help output captured from the checksum-verified glab v1.115.0 macOS arm64 release binary. Terminal padding and trailing whitespace are removed.
 
 ## dependency-firewall
 
 Alias: `df`
 
 ```text
+
   Commands to configure GitLab Dependency Firewall for local package
   managers, run local package managers with a summary of blocked or
   flagged packages, and view activity during the current session.
 
-  This feature is in beta and might not be ready for production use.
-  It might be unstable and breaking changes can occur outside of major releases.
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
   For more information, see
   https://docs.gitlab.com/policy/development_stages_support/.
 
@@ -25,58 +24,18 @@ Alias: `df`
 
   COMMANDS
 
-    ci-summary                             Summarize Dependency Firewall activity from the CI log.
-    configure <package-manager> [--flags]  Configure Dependency Firewall registry URLs for a package manager.
+    ci-summary  Summarize Dependency Firewall activity from the CI log. (EXPERIMENTAL)
 
   FLAGS
 
-    -h --help                              Show help for this command.
+    -h --help   Show help for this command.
+
 ```
-
-## dependency-firewall configure
-
-```text
-  Write a package manager's resolve and deploy registry URLs to
-  `.gitlab/df/config.json`.
-
-  Supported package managers: `npm`.
-
-  The file is written relative to the current working directory, so run this
-  command from the directory you run the package manager in.
-
-  Only the flags you pass are updated; existing values and unknown keys are
-  preserved.
-
-  This feature is in beta and might not be ready for production use.
-  It might be unstable and breaking changes can occur outside of major releases.
-  For more information, see
-  https://docs.gitlab.com/policy/development_stages_support/.
-
-
-  USAGE
-
-    glab dependency-firewall configure <package-manager> [--flags]
-
-  EXAMPLES
-
-    # Set the resolve (read) and deploy (publish) registry URLs for npm
-    glab dependency-firewall configure npm --repo-resolve https://gitlab.com/api/v4/projects/42/packages/npm/ --rep…
-
-    # Update only the resolve URL; the deploy URL is preserved
-    glab dependency-firewall configure npm --repo-resolve https://gitlab.com/api/v4/projects/42/packages/npm/
-
-  FLAGS
-
-    -h --help       Show help for this command.
-    --repo-deploy   Full registry URL to deploy (publish) packages to.
-    --repo-resolve  Full registry URL to resolve (install) packages from.
-```
-
-At least one of `--repo-deploy` or `--repo-resolve` is required. The only accepted package-manager positional in this command surface is `npm`.
 
 ## dependency-firewall ci-summary
 
 ```text
+
   Read `.gitlab/df/ci-log.json` and print blocked and flagged packages
   recorded during a `glab dependency-firewall` run.
 
@@ -90,8 +49,8 @@ At least one of `--repo-deploy` or `--repo-resolve` is required. The only accept
   | `1` | The log could not be read. |
   | `3` | At least one entry in the log is blocked. |
 
-  This feature is in beta and might not be ready for production use.
-  It might be unstable and breaking changes can occur outside of major releases.
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
   For more information, see
   https://docs.gitlab.com/policy/development_stages_support/.
 
@@ -108,4 +67,5 @@ At least one of `--repo-deploy` or `--repo-resolve` is required. The only accept
   FLAGS
 
     -h --help  Show help for this command.
+
 ```

--- a/glab-issue/SKILL.md
+++ b/glab-issue/SKILL.md
@@ -13,6 +13,10 @@ Create, view, update, and manage GitLab issues.
 # Create an issue
 glab issue create --title "Fix login bug" --label bug
 
+# Create or update with a multi-line description from a file
+glab issue create --title "Fix login bug" --description-file description.md
+glab issue update 123 --description-file description.md
+
 # List open issues
 glab issue list --state opened
 
@@ -63,6 +67,8 @@ glab issue update https://gitlab.com/group/project/-/work_items/123 --label need
      --label bug
    ```
 
+   For one-off multi-line descriptions, use `--description-file <path>` or `--description-file -` for stdin. It is mutually exclusive with `--description`; on create, it is also mutually exclusive with `--template`. A file containing exactly `-` is rejected because `--description -` means "open an editor".
+
 2. **Add reproduction steps:**
    ```bash
    glab issue note 456 -m "Steps to reproduce:
@@ -86,6 +92,8 @@ glab issue update https://gitlab.com/group/project/-/work_items/123 --label need
      --label backend,priority::medium \
      --assignee @backend-team \
      --milestone "Sprint 23"
+
+   glab issue update 789 --description-file triage-summary.md
    ```
 
 3. **Remove triage label:**

--- a/glab-issue/references/commands.md
+++ b/glab-issue/references/commands.md
@@ -103,36 +103,54 @@ FLAGS
 
 ```
 
-  Create an issue.                                                                                                      
-         
-  USAGE  
-         
-    glab issue create [--flags]                                                              
-            
-  EXAMPLES  
-            
-    $ glab issue create                                                                      
-    $ glab issue new                                                                         
-    $ glab issue create -m release-2.0.0 -t "we need this feature" --label important         
-    $ glab issue new -t "Fix CVE-YYYY-XXXX" -l security --linked-mr 123                      
-    $ glab issue create -m release-1.0.1 -t "security fix" --label security --web --recover  
-         
-  FLAGS  
-         
+  Opens an editor to draft the issue unless you pass a title and
+  description. Use `--web` to create the issue in your browser, or
+  `--template` to start from an issue template.
+
+  The `--recover` flag is an experiment: it might be unstable or
+  removed at any time, and is not ready for production use. For more
+  information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab issue create [--flags]
+
+  EXAMPLES
+
+    glab issue create
+    glab issue new
+    glab issue create -m release-2.0.0 -t "we need this feature" --label important
+    glab issue new -t "Fix CVE-YYYY-XXXX" -l security --linked-mr 123
+    glab issue create -m release-1.0.1 -t "security fix" --label security --web --recover
+    glab issue create -t "Bug Report" --template bug
+    glab issue create -t "Feature Request" --template feature_proposal.md --yes
+
+    # Read the description from a file
+    glab issue create -t "we need this feature" --description-file description.md
+
+    # Read the description from standard input
+    cat description.md | glab issue create -t "we need this feature" --description-file -
+
+  FLAGS
+
     -a --assignee       Assign issue to people by their `usernames`. Multiple usernames can be comma-separated or specified by repeating the flag.
-    -c --confidential   Set an issue to be confidential. (default false)
+    -c --confidential   Set an issue to be confidential.
     -d --description    Issue description. Set to "-" to open an editor.
+    --description-file  Read the issue description from a file. Use "-" to read from standard input.
     --due-date          A date in 'YYYY-MM-DD' format.
     --epic              Id of the epic to add the issue to.
     -h --help           Show help for this command.
     -l --label          Add label by name. Multiple labels can be comma-separated or specified by repeating the flag.
-    --link-type         Type for the issue link (relates_to)
+    --link-type         Type for the issue link. (relates_to)
     --linked-issues     The IIDs of issues that this issue links to. Multiple IIDs can be comma-separated or specified by repeating the flag.
     --linked-mr         The IID of a merge request in which to resolve all issues.
     -m --milestone      The global ID or title of a milestone to assign.
-    --no-editor         Don't open editor to enter a description. If set to true, uses prompt. (default false)
+    --no-editor         Don't open editor to enter a description. If set to true, uses prompt.
     --recover           Save the options to a file if the issue fails to be created. If the file exists, the options will be loaded from the recovery file. (EXPERIMENTAL)
-    -R --repo           Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo           Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+    --template          Name of a template in '.gitlab/issue_templates/' to pre-populate the description. The '.md' extension is optional. Templates are loaded from the local repository only.
     -e --time-estimate  Set time estimate for the issue.
     -s --time-spent     Set time spent for the issue.
     -t --title          Issue title.
@@ -295,29 +313,39 @@ FLAGS
 
 ```
 
-  Update issue                                                                                                          
-         
-  USAGE  
-         
-    glab issue update <id> [--flags]          
-            
-  EXAMPLES  
-            
-    $ glab issue update 42 --label ui,ux      
-    $ glab issue update 42 --unlabel working  
-         
-  FLAGS  
-         
+  Change an issue's labels, assignees, milestone, title, or
+  description. Use `--label` and `--unlabel` to add or remove
+  labels.
+
+
+  USAGE
+
+    glab issue update <id> [--flags]
+
+  EXAMPLES
+
+    glab issue update 42 --label ui,ux
+    glab issue update 42 --unlabel working
+
+    # Read the description from a file
+    glab issue update 42 --description-file description.md
+
+    # Read the description from standard input
+    cat description.md | glab issue update 42 --description-file -
+
+  FLAGS
+
     -a --assignee        Assign users by username. Prefix with '!' or '-' to remove from existing assignees, or '+' to add new. Otherwise, replace existing assignees with these users. Multiple usernames can be comma-separated or specified by repeating the flag.
-    -c --confidential    Make issue confidential
+    -c --confidential    Make issue confidential.
     -d --description     Issue description. Set to "-" to open an editor.
+    --description-file   Read the issue description from a file. Use "-" to read from standard input.
     --due-date           A date in 'YYYY-MM-DD' format.
     -h --help            Show help for this command.
     -l --label           Add labels.
     --lock-discussion    Lock discussion on issue.
     -m --milestone       Title of the milestone to assign Set to "" or 0 to unassign.
     -p --public          Make issue public.
-    -R --repo            Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo            Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
     -t --title           Title of issue.
     --unassign           Unassign all users.
     -u --unlabel         Remove labels.
@@ -354,4 +382,3 @@ FLAGS
     -s --system-logs  Show system activities and logs.
     -w --web          Open issue in a browser. Uses the default browser, or the browser specified in the $BROWSER variable.
 ```
-

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -13,6 +13,10 @@ Create, view, and manage GitLab merge requests.
 # Create MR from current branch
 glab mr create --fill
 
+# Create or update with a multi-line description from a file
+glab mr create --title "Fix login bug" --description-file description.md
+glab mr update 123 --description-file description.md
+
 # List my MRs
 glab mr list --assignee=@me
 
@@ -39,6 +43,8 @@ glab mr create --fill --auto-merge
 # Start from an MR template file when your project uses one
 glab mr create --fill --template .gitlab/merge_request_templates/default.md
 ```
+
+For one-off multi-line descriptions, use `--description-file <path>` or `--description-file -` for stdin. It is mutually exclusive with `--description`; on create, it is also mutually exclusive with `--template`. A file containing exactly `-` is rejected because `--description -` means "open an editor".
 
 In a non-interactive environment, an explicit `--title` is sufficient; glab can create the MR with an empty description instead of requiring a TTY or `--description`. Interactive terminals still prompt for a missing description/template. For deterministic automation, pass `--yes` plus any source/target/repository selectors explicitly.
 
@@ -147,6 +153,8 @@ This automatically: checks out → runs tests → posts result → approves if p
 ```bash
 glab mr merge 123 --when-pipeline-succeeds --remove-source-branch
 ```
+
+Merge output reports the resulting merge request state accurately. Do not assume a successful `glab mr merge --auto-merge` prints `Merged!`; when the MR is only armed for auto-merge, automation should treat the accepted state as pending rather than already merged.
 
 **Squash commits:**
 ```bash

--- a/glab-mr/references/commands.md
+++ b/glab-mr/references/commands.md
@@ -215,6 +215,12 @@
     # Create a fork merge request from your fork into the upstream project, without a local clone.
     glab mr create --repo upstream/project --head your-namespace/project --source-branch feature-branch --target-br…
 
+    # Read the description from a file
+    glab mr create -t "Fix login bug" --description-file description.md
+
+    # Read the description from standard input
+    cat description.md | glab mr create -t "Fix login bug" --description-file -
+
   FLAGS
 
     --allow-collaboration   Allow commits from other members. Set to true/false to override project defaults, or omit to use project settings.
@@ -223,6 +229,7 @@
     --copy-issue-labels     Copy labels from issue to the merge request. Used with --related-issue.
     --create-source-branch  Create a source branch if it does not exist.
     -d --description        Supply a description for the merge request. Set to "-" to open an editor.
+    --description-file      Read the merge request description from a file. Use "-" to read from standard input.
     --draft                 Mark merge request as a draft.
     -f --fill               Do not prompt for title or description, and just use commit info. Sets `push` to `true`, and pushes the branch.
     --fill-commit-body      Fill description with each commit body when multiple commits. Can only be used with --fill.
@@ -425,20 +432,25 @@ Command "for" is deprecated, use `glab mr create --related-issue <issueID>`
 
 ```
 
-  Merge or accept a merge request.
+  Defaults to the currently checked-out branch. When a pipeline is running,
+  auto-merge is enabled by default. Pass `--auto-merge=false` to
+  merge immediately. Use `--squash` or `--rebase` to control
+  the merge strategy, or `--remove-source-branch` to delete the
+  source branch after merging.
+
 
   USAGE
 
-    glab mr merge {<id> | <branch>} [--flags]
+    glab mr merge [<id | branch>] [--flags]
 
   EXAMPLES
 
     # Merge a merge request
-    $ glab mr merge 235
-    $ glab mr accept 235
+    glab mr merge 235
+    glab mr accept 235
 
     # Finds open merge request from current branch
-    $ glab mr merge
+    glab mr merge
 
   FLAGS
 
@@ -447,7 +459,7 @@ Command "for" is deprecated, use `glab mr create --related-issue <issueID>`
     -m --message               Custom merge commit message.
     -r --rebase                Rebase the commits onto the base branch.
     -d --remove-source-branch  Remove source branch on merge.
-    -R --repo                  Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo                  Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
     --sha                      Merge only if the HEAD of the source branch matches this SHA. Use to ensure that only reviewed commits are merged.
     -s --squash                Squash commits on merge.
     --squash-message           Custom squash commit message.
@@ -698,7 +710,9 @@ INHERITED FLAGS
 
 ```
 
-  Update a merge request.
+  Defaults to the currently checked-out branch. Use `--fill` to
+  automatically fill the title and description from the commit history.
+
 
   USAGE
 
@@ -707,21 +721,28 @@ INHERITED FLAGS
   EXAMPLES
 
     # Mark a merge request as ready
-    $ glab mr update 23 --ready
+    glab mr update 23 --ready
 
     # Mark a merge request as draft
-    $ glab mr update 23 --draft
+    glab mr update 23 --draft
 
     # Updates the merge request for the current branch
-    $ glab mr update --draft
+    glab mr update --draft
 
     # Update merge request with commit information
-    $ glab mr update 23 --fill --fill-commit-body --yes
+    glab mr update 23 --fill --fill-commit-body --yes
+
+    # Read the description from a file
+    glab mr update 23 --description-file description.md
+
+    # Read the description from standard input
+    cat description.md | glab mr update 23 --description-file -
 
   FLAGS
 
     -a --assignee           Assign users via username. Prefix with '!' or '-' to remove from existing assignees, '+' to add. Otherwise, replace existing assignees with given users. Multiple usernames can be comma-separated or specified by repeating the flag.
     -d --description        Merge request description. Set to "-" to open an editor.
+    --description-file      Read the merge request description from a file. Use "-" to read from standard input.
     --draft                 Mark merge request as a draft.
     -f --fill               Do not prompt for title or body, and just use commit info.
     --fill-commit-body      Fill body with each commit body when multiple commits. Can only be used with --fill.
@@ -731,7 +752,7 @@ INHERITED FLAGS
     -m --milestone          Title of the milestone to assign. Set to "" or 0 to unassign.
     -r --ready              Mark merge request as ready to be reviewed and merged.
     --remove-source-branch  Toggles the removal of the source branch on merge.
-    -R --repo               Select another repository. Can use either `OWNER/REPO` or `GROUP/NAMESPACE/REPO` format. Also accepts full URL or Git URL.
+    -R --repo               Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
     --reviewer              Request review from users by their usernames. Prefix with '!' or '-' to remove from existing reviewers, '+' to add. Otherwise, replace existing reviewers with given users. Multiple usernames can be comma-separated or specified by repeating the flag.
     --squash-before-merge   Toggles the option to squash commits into a single commit when merging.
     --target-branch         Set target branch.
@@ -777,4 +798,3 @@ INHERITED FLAGS
     --unresolved      Show only unresolved discussions (implies --comments).
     -w --web          Open merge request in a browser. Uses default browser or browser specified in BROWSER variable.
 ```
-

--- a/glab-orbit/SKILL.md
+++ b/glab-orbit/SKILL.md
@@ -1,47 +1,48 @@
 ---
 name: glab-orbit
-description: Query the GitLab Knowledge Graph (Orbit) from the CLI. Use when discovering Orbit availability, inspecting schema/DSL/tools, running graph queries, or checking graph indexing status. Triggers on orbit, knowledge graph, graph query, orbit schema, orbit remote query, orbit dsl, orbit tools.
+description: Run the managed Orbit CLI for GitLab Knowledge Graph workflows through glab. Use when discovering Orbit availability, running remote or local Orbit commands, installing or updating the managed orbit-cli binary, or troubleshooting Orbit pass-through authentication. Triggers on orbit, knowledge graph, graph query, orbit remote query, orbit-cli, glab orbit, orbit binary.
 ---
 
 # glab orbit
 
-Access the GitLab Knowledge Graph (product name: **Orbit**) from `glab`.
+Run the managed Orbit CLI for the GitLab Knowledge Graph (product name: **Orbit**) through `glab`.
 
-The user-facing surface is the experimental `glab orbit` command family, covering **remote** Knowledge Graph access, guided setup, and the Orbit local CLI wrapper.
+`glab orbit` routes through the managed `orbit-cli` binary. `glab` downloads, verifies, and updates that binary on first use, then forwards commands and flags verbatim. `glab orbit remote <command>` injects the resolved GitLab credential; other Orbit commands run the managed binary without extra auth environment.
 
 ## ⚠️ Experimental Feature
 
 Upstream marks Orbit as **EXPERIMENTAL**:
-- command shape may change
+- most command shape now belongs to the managed `orbit-cli` binary and may change independently
 - the API is gated behind the `knowledge_graph` feature flag
 - access is user-scoped, not project-scoped
-- `glab orbit local` downloads/runs a local Orbit CLI binary and may have separate host/platform constraints
+- `glab orbit --install` and `glab orbit --update` install or refresh the managed binary without running it
 
 See: https://docs.gitlab.com/policy/development_stages_support/
 
 ## Quick start
 
 ```bash
-# First: confirm the service is available for your user
+# First: confirm the service is available for your user; glab injects auth for remote commands
 glab orbit remote status
 
-# Guided onboarding: verify access, install the Orbit agent skill, and install local CLI
-glab orbit setup
+# Guided onboarding through the Orbit binary
+glab orbit setup claude
 
-# Discover the graph model
+# Discover the graph model through orbit-cli
 glab orbit remote schema
 glab orbit remote dsl
 glab orbit remote tools
 
-# Inspect specific node types
-glab orbit remote schema User Project MergeRequest
+# Install or update the managed binary without running a command
+glab orbit --install
+glab orbit --update
 ```
 
 ## Recommended workflow: discover first, query second
 
-The upstream docs strongly point to a discovery-first flow:
+Use the Orbit binary's discovery-first flow:
 
-1. `glab orbit setup` or `glab orbit remote status` — verify Orbit is enabled and reachable
+1. `glab orbit setup claude` or `glab orbit remote status` — verify Orbit is enabled and reachable
 2. `glab orbit remote schema` — inspect the ontology (entities, edges, properties)
 3. `glab orbit remote dsl` — inspect the authoritative JSON Schema for the query DSL
 4. `glab orbit remote tools` — inspect the MCP tool manifest when integrating with agents/tools
@@ -51,26 +52,20 @@ That order matters because `schema` and `dsl` are the source of truth for what t
 
 ## Common workflows
 
-### 0) Guided setup
+### 0) Managed binary setup
 
 ```bash
-# Interactive onboarding: checks access, prompts to install the skill, prompts to install local CLI
-glab orbit setup
+# Install the managed binary without running it
+glab orbit --install
 
-# Non-interactive setup: accept all prompts
-glab orbit setup --yes
+# Check for and install updates to the managed binary
+glab orbit --update
 
-# Verify reachability only
-glab orbit setup --skip-skill --skip-local
-
-# Install the Orbit skill at user scope instead of in the current repo
-glab orbit setup --global
-
-# Refresh the skill and update the local CLI binary in place
-glab orbit setup --upgrade
+# Skip wrapper confirmation prompts in non-interactive environments
+glab orbit --install --yes
 ```
 
-Use `--path <path>` for a custom skill install directory, `--hostname <host>` to verify a specific GitLab host, and `--skip-skill` / `--skip-local` when you only want part of the onboarding.
+Use `orbit_local_auto_download=true` and `orbit_local_auto_run=true` in glab config, or the matching `ORBIT_LOCAL_AUTO_DOWNLOAD=true` and `ORBIT_LOCAL_AUTO_RUN=true` environment variables, when a non-interactive environment must allow the managed binary to download and run.
 
 ### 1) Check service health
 
@@ -116,7 +111,7 @@ glab orbit remote tools
 
 ### 5) Run a remote query
 
-`glab orbit remote query` reads a full Orbit query envelope from a file or stdin:
+`glab orbit remote query` is forwarded to the managed Orbit binary and reads a full Orbit query envelope from a file or stdin:
 
 ```json
 {
@@ -139,7 +134,7 @@ glab orbit remote query --response-format raw ./query.json
 Notes:
 - Default output is `llm`, which is compact and agent-friendly.
 - Use `--response-format raw` when you want structured JSON for further processing.
-- `--format` / `-f` are deprecated compatibility aliases; update scripts to `--response-format` so deprecation warnings stay out of automation logs.
+- Prefer the current Orbit binary's `--response-format` spelling when available; avoid deprecated compatibility aliases in durable automation.
 - The query body shape is defined by `glab orbit remote dsl`, not by guesswork.
 
 ### 6) Check indexing progress
@@ -180,8 +175,12 @@ Use `graph-status` when a query looks incomplete and you need to confirm whether
 - Prefer `--response-format raw` when debugging exact response structure.
 
 **Need local/offline graph commands:**
-- Use `glab orbit setup` to install the local CLI binary, then `glab orbit local` to run it.
+- Use `glab orbit --install` to install the managed binary, then run local Orbit commands through `glab orbit local ...`.
 - Keep remote discovery (`status`, `schema`, `dsl`, `tools`) in the workflow so generated local queries still match the server-side graph model.
+
+**Orbit binary fails before command execution:**
+- Reinstall with `glab orbit --update`.
+- On Windows ARM64, upstream reports x86_64 binary execution failures as an Orbit CLI execution error.
 
 ## Related skills
 
@@ -192,39 +191,17 @@ Use `graph-status` when a query looks incomplete and you need to confirm whether
 ## Command reference
 
 ```text
-glab orbit remote status [flags]
-  --hostname    Target GitLab host
+glab orbit [<command>] [flags]
+  --install  Install the Orbit binary without running it
+  --update   Check for and install updates to the binary
+  --yes      Skip confirmation prompts
 
-glab orbit remote schema [node...] [flags]
-  --hostname    Target GitLab host
-
-glab orbit remote dsl [flags]
-  --hostname    Target GitLab host
-
-glab orbit remote tools [flags]
-  --hostname    Target GitLab host
-
-glab orbit remote query [file|-] [flags]
-  --hostname         Target GitLab host
-  --response-format  llm|raw (default: llm)
-
-glab orbit remote graph-status [flags]
-  --full-path        Project/group full path
-  --hostname         Target GitLab host
-  --jq               Filter JSON output with a jq expression
-  --namespace-id     Group ID
-  --project-id       Project ID
-  --response-format  raw|llm (default: raw)
-
-glab orbit setup [flags]
-  --global      Install the Orbit skill at user scope (`~/.agents/skills/`)
-  --hostname    GitLab hostname to verify
-  --path        Custom Orbit skill install directory
-  --skip-local  Skip the local CLI binary install step
-  --skip-skill  Skip the agent-skill install step
-  --upgrade     Re-fetch the skill and update the local CLI binary in place
-  --yes         Skip every confirmation prompt
-
-glab orbit local [command] [flags]
-  Runs the Orbit local CLI; setup/download may happen before first use.
+Known forwarded workflows include:
+  glab orbit setup claude
+  glab orbit remote status
+  glab orbit remote query ./query.json
+  glab orbit remote graph-status --full-path gitlab-org/gitlab
+  glab orbit local index
+  glab orbit local sql "SELECT 1"
+  glab orbit version
 ```

--- a/glab-repo/SKILL.md
+++ b/glab-repo/SKILL.md
@@ -70,6 +70,8 @@ glab repo search "keyword"
 
    SSH configurations that map `gitlab.com` to the official `altssh.gitlab.com` endpoint are recognized as GitLab.com rather than as a separate self-managed host.
 
+   For self-managed hosts that include a port, glab keys subfolder config lookup on the full host with port. If a repository resolves to the wrong API host or misses a configured subfolder, verify the exact host key in `glab config path` includes the port.
+
 3. **Initialize with content:**
    ```bash
    echo "# My Project" > README.md

--- a/glab-repo/SKILL.md
+++ b/glab-repo/SKILL.md
@@ -70,7 +70,7 @@ glab repo search "keyword"
 
    SSH configurations that map `gitlab.com` to the official `altssh.gitlab.com` endpoint are recognized as GitLab.com rather than as a separate self-managed host.
 
-   For self-managed hosts that include a port, glab keys subfolder config lookup on the full host with port. If a repository resolves to the wrong API host or misses a configured subfolder, verify the exact host key in `glab config path` includes the port.
+   For self-managed hosts that include a port, glab keys subfolder config lookup on the full host with port. If a repository resolves to the wrong API host or misses a configured subfolder, verify the exact host key in the config file at `glab config path` includes the port.
 
 3. **Initialize with content:**
    ```bash

--- a/glab-workitems/SKILL.md
+++ b/glab-workitems/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: glab-workitems
-description: Create, list, and delete GitLab work items (tasks, OKRs, key results, epics, incidents, test cases). Use when working with GitLab's work item types beyond standard issues. Triggers on work items, work-items, tasks, OKRs, key results, epics, work item create, work item delete.
+description: Create, list, update, and delete GitLab work items (tasks, OKRs, key results, epics, incidents, test cases). Use when working with GitLab's work item types beyond standard issues. Triggers on work items, work-items, tasks, OKRs, key results, epics, work item create, work item update, work item delete.
 ---
 
 # glab work-items
@@ -25,6 +25,10 @@ glab work-items list
 
 # Create a task in the current project
 glab work-items create --type task --title "Follow up on flaky pipeline"
+
+# Create or update with a multi-line description from a file
+glab work-items create --type task --title "Follow up" --description-file description.md
+glab work-items update 42 --description-file description.md
 
 # Create a group-scoped epic
 glab work-items create --type epic --group my-group --title "Platform rewrite"
@@ -93,6 +97,8 @@ glab work-items create \
 glab work-items create --type issue --title "Backfill docs" --output json
 ```
 
+For one-off multi-line descriptions, use `--description-file <path>` or `--description-file -` for stdin. It is mutually exclusive with `--description`. A file containing exactly `-` is rejected because `--description -` means "open an editor".
+
 Supported upstream type values include:
 `epic`, `incident`, `issue`, `key_result`, `objective`, `requirement`, `task`, `test_case`, and `ticket`.
 
@@ -110,6 +116,16 @@ glab work-items delete 42 --repo mygroup/myproject --output json
 ```
 
 `delete` is destructive. Double-check whether the IID belongs to the intended project or group before running it.
+
+### Update work items
+
+```bash
+# Update body text in the current project
+glab work-items update 42 --description-file description.md
+
+# Update a group-scoped work item
+glab work-items update 40 --group MYGROUP --description-file epic-update.md
+```
 
 ## Work items vs issues
 
@@ -149,6 +165,8 @@ Use `glab work-items` when the work type itself matters. Use `glab issue` when y
 
 ## Command reference
 
+For complete captured help for affected commands, see [references/commands.md](references/commands.md).
+
 ```text
 glab work-items <command> [flags]
 
@@ -162,13 +180,27 @@ glab work-items list [flags]
   --type         One or more work item types
 
 glab work-items create [flags]
-  --confidential Mark the work item confidential
-  --description  Body text (use - to open editor)
-  --group        Group/subgroup scope
-  --output       text|json
-  --repo         Project scope override
-  --title        Title for the new work item
-  --type         epic|incident|issue|key_result|objective|requirement|task|test_case|ticket
+  --confidential    Mark the work item confidential
+  --description     Body text (use - to open editor)
+  --description-file Read body text from a file or stdin
+  --group           Group/subgroup scope
+  --output          text|json
+  --repo            Project scope override
+  --title           Title for the new work item
+  --type            epic|incident|issue|key_result|objective|requirement|task|test_case|ticket
+
+glab work-items update <iid> [flags]
+  --assignee         Update assignees
+  --description      Body text
+  --description-file Read body text from a file or stdin
+  --duedate          Update due date
+  --group            Group/subgroup scope
+  --milestone        Update milestone
+  --output           text|json
+  --repo             Project scope override
+  --startdate        Update start date
+  --title            Update title
+  --weight           Update weight
 
 glab work-items delete <iid> [flags]
   --group        Group/subgroup scope

--- a/glab-workitems/SKILL.md
+++ b/glab-workitems/SKILL.md
@@ -180,14 +180,14 @@ glab work-items list [flags]
   --type         One or more work item types
 
 glab work-items create [flags]
-  --confidential    Mark the work item confidential
-  --description     Body text (use - to open editor)
+  --confidential     Mark the work item confidential
+  --description      Body text (use - to open editor)
   --description-file Read body text from a file or stdin
-  --group           Group/subgroup scope
-  --output          text|json
-  --repo            Project scope override
-  --title           Title for the new work item
-  --type            epic|incident|issue|key_result|objective|requirement|task|test_case|ticket
+  --group            Group/subgroup scope
+  --output           text|json
+  --repo             Project scope override
+  --title            Title for the new work item
+  --type             epic|incident|issue|key_result|objective|requirement|task|test_case|ticket
 
 glab work-items update <iid> [flags]
   --assignee         Update assignees

--- a/glab-workitems/references/commands.md
+++ b/glab-workitems/references/commands.md
@@ -1,0 +1,132 @@
+# glab work-items command reference
+
+> Help output captured from the checksum-verified glab v1.115.0 macOS arm64 release binary. Terminal padding and trailing whitespace are removed.
+
+## work-items
+
+```text
+
+  Work with GitLab work items.
+
+  Work items are the unified GitLab system for planning and tracking work, supporting
+  various types including epics, issues, tasks, incidents, and test cases. Work items
+  can be organized hierarchically to break down complex work into manageable pieces.
+
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab work-items <command> [command] [--flags]
+
+  COMMANDS
+
+    create [--flags]        Create work items in a project or group. (EXPERIMENTAL)
+    delete <iid> [--flags]  Delete a work item in a project or group. (EXPERIMENTAL)
+    list [--flags]          List work items in a project or group. (EXPERIMENTAL)
+    update <iid> [--flags]  Update work items in a project or group. (EXPERIMENTAL)
+
+  FLAGS
+
+    -h --help               Show help for this command.
+
+```
+
+## work-items create
+
+```text
+
+  Use `--type` to specify the kind of work item to create.
+  The command uses your repository context to detect scope automatically.
+
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab work-items create [--flags]
+
+  EXAMPLES
+
+    # Create a work item in the current project
+    glab work-items create --type issue
+
+    # Create a work item in a group
+    glab work-items create --type epic --group my-group
+
+    # Read the description from a file
+    glab work-items create --type issue --title "Add feature" --description-file description.md
+
+    # Read the description from standard input
+    cat description.md | glab work-items create --type issue --title "Add feature" --description-file -
+
+  FLAGS
+
+    -c --confidential   Mark work item confidential.
+    -d --description    Description of the work item. Set to "-" to open an editor.
+    --description-file  Read the work item description from a file. Use "-" to read from standard input.
+    -g --group          Create work items for a group or subgroup.
+    -h --help           Show help for this command.
+    --jq                Filter JSON output with a jq expression.
+    -F --output         Format output as: text, json. (text)
+    -R --repo           Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+    -t --title          Add a title for the work item.
+    -T --type           Type of work item (epic, incident, issue, key_result, objective, requirement, task, test_case, ticket).
+
+```
+
+## work-items update
+
+```text
+
+  The command uses your repository context to detect scope automatically.
+
+  Use `--group` to target a group or subgroup. `--group` and `--repo` are mutually exclusive.
+
+  This feature is an experiment and is not ready for production use.
+  It might be unstable or removed at any time.
+  For more information, see
+  https://docs.gitlab.com/policy/development_stages_support/.
+
+
+  USAGE
+
+    glab work-items update <iid> [--flags]
+
+  EXAMPLES
+
+    # Update a work item in current project
+    glab work-items update 42 --description "this issue tracks a new feature"
+
+    # Update a work item in a group
+    glab work-items update 40 --group MYGROUP --description "this epic tracks a new feature"
+
+    # Read the description from a file
+    glab work-items update 42 --description-file description.md
+
+    # Read the description from standard input
+    cat description.md | glab work-items update 42 --description-file -
+
+  FLAGS
+
+    -a --assignee       Update the work item assignee with the supplied GitLab usernames.
+    -d --description    Update the description for the work item.
+    --description-file  Read the work item description from a file. Use "-" to read from standard input.
+    --duedate           Update the due date for the work item.
+    -g --group          Update work items for a group or subgroup.
+    -h --help           Show help for this command.
+    --jq                Filter JSON output with a jq expression.
+    -m --milestone      Update the work item milestone with the title or ID.
+    -F --output         Format output as: text, json. (text)
+    -R --repo           Select another repository. You can use either OWNER/REPO or GROUP/NAMESPACE/REPO. The full URL or Git URL is also accepted.
+    --startdate         Update the start date for the work item.
+    -t --title          Update the title for the work item.
+    -w --weight         Update the weight value for the work item.
+
+```


### PR DESCRIPTION
## Upstream

- **Version:** GitLab CLI `glab` v1.115.0
- **Canonical source:** https://gitlab.com/gitlab-org/cli/-/releases/v1.115.0
- **Release API:** https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/v1.115.0

## CLI changes evaluated

- Added Artifact Registry login configuration for Maven, Gradle, npm, and sbt alongside Docker.
- Added `glab config path` and configuration/authentication write hardening.
- Added `--description-file` to issue, merge-request, and work-item create/update commands.
- Routed `glab orbit` through the managed `orbit-cli` binary.
- Marked Dependency Firewall commands experimental and exposed the current `ci-summary` surface.
- Reviewed CI child-pipeline lookup, self-managed host-with-port config lookup, and accurate MR merge-state output fixes.

## Skill/package changes

- Refreshed the affected operational skills and command references.
- Added complete work-item create/update reference captures.
- Bumped the skill package from `1.13.24` to `1.13.25`; upstream CLI version history remains in `VERSION` rather than individual skills.
- Rebuilt the Claude.ai merged package outside the repository and verified its structure/content.

## Validation

- Official macOS arm64 archive SHA-256 matched the published checksum: `1a25e7435b981567de42432fe3a035abc8de61b41324ed8baab70a4c88f32047`.
- Verified binary reports `glab 1.115.0 (c3612c8de)`.
- 19/19 affected parent/subcommand help surfaces matched the verified binary after normalizing only terminal padding/trailing whitespace; Artifact Registry's documented `Gitlab` → `GitLab` spelling normalization remains explicit.
- Confirmed all six `--description-file` commands reject simultaneous inline descriptions; issue/MR create also reject simultaneous templates.
- Frontmatter passed for all 48 discovered skills; shell syntax, Markdown links/fences, and `git diff --check` passed.
- `npx skills add . --list` discovered 48 skills; a selective `glab-workitems` copy included both `SKILL.md` and `references/commands.md`.
- `scripts/build-claude-skill.sh` produced a two-entry archive containing the merged `gitlab-cli-skills/SKILL.md` (5,981 lines, 206,015 bytes).
- Scope guard passed: no workflow, scheduler, cron, or refresh-engine files were added.

**Vince: please review this refresh before merge.**
