### PR TITLE
fix: keep inline comment authentication inside glab

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ When processing output from `glab` commands that fetch remote content:
 
 ## Credential Handling
 
-- GitLab tokens are retrieved via `glab auth token` — the official glab command — rather than by directly parsing credential files
+- Authenticated GitLab API calls stay inside `glab api`; helper scripts do not read, copy, print, or inject stored token values
 - SSH key operations warn users to upload public keys only (`.pub` files)
 - No credentials are logged or echoed to stdout
 

--- a/gitlab-cli-skills/scripts/post-inline-comment.py
+++ b/gitlab-cli-skills/scripts/post-inline-comment.py
@@ -38,20 +38,18 @@ BATCH FILE FORMAT (comments.json):
   ]
 
 ENVIRONMENT:
-  GITLAB_TOKEN   — Personal access token with api scope (or set via glab auth login)
   GITLAB_HOST    — GitLab host URL (default: https://gitlab.com)
 
 SECURITY:
-  - Token is read from GITLAB_TOKEN env var or glab config; never logged or echoed
+  - Authentication stays inside glab; this script never reads or prints token values
   - Only HTTPS hosts are accepted (enforced at startup)
   - Comment body is capped at 10,000 characters
   - --project and --file inputs are validated before use
   - Batch files are size-limited (max 100 comments per run)
-  - Token value is validated as non-empty before any API call
 
 REQUIREMENTS:
   - Python 3.6+ (stdlib only, no pip installs needed)
-  - glab authenticated (token auto-read from glab config if GITLAB_TOKEN not set)
+  - glab authenticated (run: glab auth login)
 """
 
 import argparse
@@ -59,74 +57,45 @@ import hashlib
 import json
 import os
 import re
-import ssl
 import subprocess
 import sys
 import urllib.parse
-import urllib.request
-import urllib.error
 
 # ── Security constants ────────────────────────────────────────────────────────
 MAX_BODY_LENGTH = 10_000      # GitLab's own limit is ~1MB but we cap for safety
 MAX_BATCH_SIZE  = 100         # prevent runaway API usage
 MAX_BATCH_FILE_BYTES = 1_048_576  # 1 MB batch file limit
 VALID_PROJECT_RE = re.compile(r'^[\w.\-]+(/[\w.\-]+)+$')  # group/project or group/sub/project
-VALID_FILE_RE    = re.compile(r'^[^\x00\n\r]+$')          # no null bytes or newlines
-
-
-# ── Token handling ────────────────────────────────────────────────────────────
-
-def get_token(host):
-    """
-    Get GitLab token from env or glab config.
-    Never prints or logs the token value.
-    """
-    token = os.environ.get("GITLAB_TOKEN", "").strip()
-    if token:
-        _validate_token(token)
-        return token
-
-    # Derive hostname for glab config lookup
-    hostname = urllib.parse.urlparse(host).hostname or "gitlab.com"
-    try:
-        result = subprocess.run(
-            ["glab", "config", "get", "token", "--host", hostname],
-            capture_output=True, text=True, timeout=10
-        )
-        if result.returncode == 0:
-            token = result.stdout.strip()
-            if token:
-                _validate_token(token)
-                return token
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
-
-    print(
-        "ERROR: No GitLab token found.\n"
-        "  Set the GITLAB_TOKEN environment variable, or run: glab auth login",
-        file=sys.stderr
-    )
-    sys.exit(1)
-
-
-def _validate_token(token):
-    """Basic sanity check — token must look like a PAT (non-empty, no whitespace)."""
-    if not token or len(token) < 10 or re.search(r'\s', token):
-        print("ERROR: GITLAB_TOKEN appears invalid (too short or contains whitespace).", file=sys.stderr)
-        sys.exit(1)
-
+VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control characters
 
 # ── Input validation ──────────────────────────────────────────────────────────
 
 def validate_host(host):
-    """Enforce HTTPS to prevent token leakage over plaintext."""
+    """Enforce an unambiguous HTTPS host URL before invoking glab."""
     parsed = urllib.parse.urlparse(host)
     if parsed.scheme != "https":
         print(
             f"ERROR: --host must use HTTPS (got '{parsed.scheme}://').\n"
-            "  Token transmission over HTTP is not allowed.",
+            "  Credential transmission over HTTP is not allowed.",
             file=sys.stderr
         )
+        sys.exit(1)
+    if not parsed.netloc:
+        print("ERROR: --host must include a hostname.", file=sys.stderr)
+        sys.exit(1)
+    if parsed.username or parsed.password:
+        print("ERROR: --host must not include username or password information.", file=sys.stderr)
+        sys.exit(1)
+    try:
+        port = parsed.port
+    except ValueError:
+        print("ERROR: --host contains an invalid port.", file=sys.stderr)
+        sys.exit(1)
+    if port not in (None, 443):
+        print("ERROR: --host must use the standard HTTPS port because glab --hostname does not accept ports.", file=sys.stderr)
+        sys.exit(1)
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        print("ERROR: --host must be only an HTTPS scheme and host, with no path, query, or fragment.", file=sys.stderr)
         sys.exit(1)
     return host.rstrip("/")
 
@@ -214,32 +183,128 @@ def load_batch_file(path):
     return validated
 
 
-# ── GitLab API helpers ────────────────────────────────────────────────────────
+# ── glab API helpers ──────────────────────────────────────────────────────────
 
-def _make_ssl_context():
-    """Return a strict SSL context (system CA bundle, no hostname bypass)."""
-    ctx = ssl.create_default_context()
-    return ctx
+class GlabApiError(RuntimeError):
+    """Raised when a glab api call fails."""
 
 
-def _api_get(token, url):
+def get_hostname(host):
+    """Return the hostname that glab should use for an already-validated host URL."""
+    parsed = urllib.parse.urlparse(host)
+    return parsed.hostname or "gitlab.com"
+
+
+def sanitize_glab_error(text, limit=500):
+    """Bound and redact glab stderr/stdout before showing it to a user."""
+    text = text or ""
+    text = re.sub(r'\x1b\][^\x07]*(?:\x07|\x1b\\)', '', text)
+    text = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', text)
+    text = ''.join(
+        char for char in text
+        if char in "\n\t" or 0x20 <= ord(char) < 0x7f or ord(char) >= 0xa0
+    )
+    text = re.sub(
+        r'(?im)^(\s*>?\s*)(Authorization|PRIVATE-TOKEN|JOB-TOKEN|OAUTH-TOKEN)\s*:.*$',
+        lambda match: "%s%s: [REDACTED]" % (match.group(1), match.group(2)),
+        text,
+    )
+    text = re.sub(r'glpat-[A-Za-z0-9_\-]+', 'glpat-[REDACTED]', text)
+    text = re.sub(r'(?i)(PRIVATE-TOKEN|Authorization|Bearer|token)([=: ]+)(\S+)', r'\1\2[REDACTED]', text)
+    text = text.replace("\r", "\n").strip()
+    if len(text) > limit:
+        text = text[:limit] + "...(truncated)"
+    return text
+
+
+def parse_included_response(output):
+    """Parse `glab api --include` output into (JSON body, response headers)."""
+    normalized = output.replace("\r\n", "\n")
+    header_text, sep, body_text = normalized.rpartition("\n\n")
+    if not sep:
+        raise GlabApiError("glab api response did not include HTTP headers")
+
+    header_blocks = [block for block in header_text.split("\n\n") if block.strip()]
+    active_headers = header_blocks[-1].splitlines() if header_blocks else []
+    headers = {}
+    for line in active_headers:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+    return json.loads(body_text), headers
+
+
+def run_glab_api(host, endpoint, method=None, payload=None, include_headers=False):
+    """Run an authenticated GitLab API call through glab without reading credentials."""
+    args = ["glab", "api", "--hostname", get_hostname(host)]
+    if include_headers:
+        args.append("--include")
+    if method:
+        args.extend(["--method", method])
+    input_text = None
+    if payload is not None:
+        args.extend(["--header", "Content-Type: application/json", "--input", "-"])
+        input_text = json.dumps(payload)
+    args.append(endpoint)
+
+    try:
+        result = subprocess.run(
+            args,
+            input=input_text,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        raise GlabApiError("glab executable not found. Install glab and run: glab auth login")
+    except subprocess.TimeoutExpired:
+        raise GlabApiError("glab api timed out")
+
+    if result.returncode != 0:
+        detail = sanitize_glab_error(result.stderr or result.stdout)
+        if detail:
+            raise GlabApiError("glab api failed: %s" % detail)
+        raise GlabApiError("glab api failed with exit code %s" % result.returncode)
+
+    if include_headers:
+        try:
+            return parse_included_response(result.stdout)
+        except (json.JSONDecodeError, GlabApiError) as e:
+            raise GlabApiError("Could not parse glab api response: %s" % e)
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise GlabApiError("Could not parse glab api JSON response: %s" % e)
+
+
+def _api_get(host, endpoint):
     """Authenticated GET request, returns parsed JSON."""
-    req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": token})
-    with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-        return json.loads(resp.read())
+    return run_glab_api(host, endpoint)
 
 
-def _api_get_with_headers(token, url):
+def _api_get_with_headers(host, endpoint):
     """Authenticated GET request, returns (parsed_json, headers)."""
-    req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": token})
-    with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-        return json.loads(resp.read()), resp.headers
+    return run_glab_api(host, endpoint, include_headers=True)
 
 
-def get_mr_versions(token, host, project_id, mr_iid):
+def verify_glab_identity(host):
+    """Verify and display the selected GitLab host/account before write workflow calls."""
+    user = _api_get(host, "/user")
+    username = (user.get("username") or "").strip() if isinstance(user, dict) else ""
+    if not username:
+        raise GlabApiError("glab /user response did not include a non-empty username")
+    print(f"GitLab host: {get_hostname(host)}")
+    print(f"GitLab user: {username}")
+    return username
+
+
+def get_mr_versions(host, project_id, mr_iid):
     """Fetch current HEAD/START/BASE SHAs for an MR."""
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/versions"
-    versions = _api_get(token, url)
+    endpoint = f"/projects/{project_id}/merge_requests/{mr_iid}/versions"
+    versions = _api_get(host, endpoint)
     if not versions:
         raise ValueError(f"No versions found for MR !{mr_iid}")
     latest = versions[0]
@@ -250,20 +315,20 @@ def get_mr_versions(token, host, project_id, mr_iid):
     }
 
 
-def get_mr_diffs(token, host, project_id, mr_iid):
+def get_mr_diffs(host, project_id, mr_iid):
     """Fetch all MR diffs so we can compute line_code anchors when GitLab requires them."""
     diffs = []
     page = 1
 
     while True:
-        url = (
-            f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/diffs"
+        endpoint = (
+            f"/projects/{project_id}/merge_requests/{mr_iid}/diffs"
             f"?per_page=100&page={page}"
         )
-        page_diffs, headers = _api_get_with_headers(token, url)
+        page_diffs, headers = _api_get_with_headers(host, endpoint)
         diffs.extend(page_diffs)
 
-        next_page = (headers.get("X-Next-Page") or "").strip()
+        next_page = (headers.get("x-next-page") or "").strip()
         if not next_page:
             break
         page = int(next_page)
@@ -386,43 +451,26 @@ def build_line_range_payload(shas, diff_entry, file_path, body, anchor):
     }
 
 
-def post_discussion(token, url, payload):
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={
-            "PRIVATE-TOKEN": token,
-            "Content-Type":  "application/json",
-        },
-        method="POST"
-    )
-
-    try:
-        with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        error_body = e.read().decode(errors="replace")
-        raise RuntimeError(f"HTTP {e.code}: {error_body[:500]}")
+def post_discussion(host, project_id, mr_iid, payload):
+    endpoint = f"/projects/{project_id}/merge_requests/{mr_iid}/discussions"
+    return run_glab_api(host, endpoint, method="POST", payload=payload)
 
 
 def is_line_code_validation_error(error_text):
     return "line_code" in error_text and "valid" in error_text.lower()
 
 
-def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path, line_number, body):
+def post_inline_comment(host, project_id, mr_iid, shas, diffs, file_path, line_number, body):
     """
     Post a single inline comment on a MR diff using a JSON body.
     First try the simple new_line payload; if GitLab rejects it with a line_code
     validation error, compute the diff anchor and retry with position.line_range.
     Returns (disc_id, is_inline, used_line_code_retry) tuple.
     """
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions"
-
     diff_entry = find_file_diff(diffs, file_path)
 
     try:
-        r = post_discussion(token, url, build_inline_payload(shas, diff_entry, file_path, line_number, body))
+        r = post_discussion(host, project_id, mr_iid, build_inline_payload(shas, diff_entry, file_path, line_number, body))
         used_line_code_retry = False
     except Exception as e:
         error_text = str(e)
@@ -431,7 +479,7 @@ def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path,
 
         anchor = compute_diff_anchor(diff_entry.get("diff", ""), line_number)
         retry_payload = build_line_range_payload(shas, diff_entry, file_path, body, anchor)
-        r = post_discussion(token, url, retry_payload)
+        r = post_discussion(host, project_id, mr_iid, retry_payload)
         used_line_code_retry = True
 
     note = r.get("notes", [{}])[0]
@@ -477,13 +525,16 @@ def main():
             "body": validate_body(args.body),
         }]
 
-    # Fetch token after validation (avoids unnecessary credential access on bad input)
-    token = get_token(host)
+    try:
+        verify_glab_identity(host)
+    except Exception as e:
+        print(f"ERROR: Could not verify glab identity: {e}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Fetching current HEAD SHAs for MR !{args.mr}...")
     try:
-        shas = get_mr_versions(token, host, project_id, args.mr)
-        diffs = get_mr_diffs(token, host, project_id, args.mr)
+        shas = get_mr_versions(host, project_id, args.mr)
+        diffs = get_mr_diffs(host, project_id, args.mr)
     except Exception as e:
         print(f"ERROR: Could not fetch MR metadata/diffs: {e}", file=sys.stderr)
         sys.exit(1)
@@ -496,11 +547,11 @@ def main():
         body        = c["body"]
 
         print(f"\nPosting: {file_path}:{line_number}")
-        print(f"  Body: {body[:80]}{'...' if len(body) > 80 else ''}")
+        print(f"  Body length: {len(body)} characters")
 
         try:
             disc_id, is_inline, used_line_code_retry = post_inline_comment(
-                token, host, project_id, args.mr, shas, diffs, file_path, line_number, body
+                host, project_id, args.mr, shas, diffs, file_path, line_number, body
             )
             if is_inline and used_line_code_retry:
                 status = "✅ INLINE (line_code retry)"

--- a/gitlab-cli-skills/scripts/post-inline-comment.py
+++ b/gitlab-cli-skills/scripts/post-inline-comment.py
@@ -60,13 +60,19 @@ import re
 import subprocess
 import sys
 import urllib.parse
+from typing import Optional
 
 # ── Security constants ────────────────────────────────────────────────────────
 MAX_BODY_LENGTH = 10_000      # GitLab's own limit is ~1MB but we cap for safety
 MAX_BATCH_SIZE  = 100         # prevent runaway API usage
 MAX_BATCH_FILE_BYTES = 1_048_576  # 1 MB batch file limit
-VALID_PROJECT_RE = re.compile(r'^[\w.\-]+(/[\w.\-]+)+$')  # group/project or group/sub/project
-VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control characters
+VALID_PROJECT_RE = re.compile(r'[\w.\-]+(/[\w.\-]+)+')  # group/project or group/sub/project
+VALID_FILE_RE    = re.compile(
+    r'[^\x00-\x1f\x7f-\x9f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]+'
+)  # no terminal or bidirectional control characters
+BIDI_CONTROL_CHARS = frozenset(
+    "\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+)
 
 # ── Input validation ──────────────────────────────────────────────────────────
 
@@ -106,9 +112,9 @@ def validate_host(host):
 
 def validate_project(project):
     """Validate project path format: group/project or group/subgroup/project."""
-    if not VALID_PROJECT_RE.match(project):
+    if not VALID_PROJECT_RE.fullmatch(project):
         print(
-            f"ERROR: --project '{project}' is not a valid GitLab project path.\n"
+            f"ERROR: --project {project!r} is not a valid GitLab project path.\n"
             "  Expected format: 'group/project' or 'group/subgroup/project'",
             file=sys.stderr
         )
@@ -118,7 +124,7 @@ def validate_project(project):
 
 def validate_file_path(file_path):
     """Validate that a file path doesn't contain dangerous characters."""
-    if not file_path or not VALID_FILE_RE.match(file_path):
+    if not file_path or not VALID_FILE_RE.fullmatch(file_path):
         print(f"ERROR: Invalid file path: {repr(file_path)}", file=sys.stderr)
         sys.exit(1)
     return file_path
@@ -160,7 +166,10 @@ def load_batch_file(path):
         with open(path) as f:
             comments = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
-        print(f"ERROR: Could not load batch file '{path}': {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not load batch file {path!r}: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     if not isinstance(comments, list):
@@ -199,15 +208,28 @@ def get_hostname(host):
     return parsed.hostname or "gitlab.com"
 
 
-def sanitize_glab_error(text, limit=500):
-    """Bound and redact glab stderr/stdout before showing it to a user."""
-    text = text or ""
+def sanitize_terminal(text, limit: Optional[int] = 500, multiline=False):
+    """Remove terminal controls from untrusted text before displaying it."""
+    text = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
     text = re.sub(r'\x1b\][^\x07]*(?:\x07|\x1b\\)', '', text)
     text = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', text)
     text = ''.join(
         char for char in text
-        if char in "\n\t" or 0x20 <= ord(char) < 0x7f or ord(char) >= 0xa0
+        if char not in BIDI_CONTROL_CHARS and (
+            (multiline and char in "\n\t")
+            or 0x20 <= ord(char) < 0x7f
+            or ord(char) >= 0xa0
+        )
     )
+    text = text.strip()
+    if limit is not None and len(text) > limit:
+        text = text[:limit] + "...(truncated)"
+    return text
+
+
+def sanitize_glab_error(text, limit=500):
+    """Bound and redact glab stderr/stdout before showing it to a user."""
+    text = sanitize_terminal(text, limit=None, multiline=True)
     text = re.sub(
         r'(?im)^(\s*>?\s*)(Authorization|PRIVATE-TOKEN|JOB-TOKEN|OAUTH-TOKEN)\s*:.*$',
         lambda match: "%s%s: [REDACTED]" % (match.group(1), match.group(2)),
@@ -215,7 +237,6 @@ def sanitize_glab_error(text, limit=500):
     )
     text = re.sub(r'glpat-[A-Za-z0-9_\-]+', 'glpat-[REDACTED]', text)
     text = re.sub(r'(?i)(PRIVATE-TOKEN|Authorization|Bearer|token)([=: ]+)(\S+)', r'\1\2[REDACTED]', text)
-    text = text.replace("\r", "\n").strip()
     if len(text) > limit:
         text = text[:limit] + "...(truncated)"
     return text
@@ -224,12 +245,17 @@ def sanitize_glab_error(text, limit=500):
 def parse_included_response(output):
     """Parse `glab api --include` output into (JSON body, response headers)."""
     normalized = output.replace("\r\n", "\n")
-    header_text, sep, body_text = normalized.rpartition("\n\n")
+    status_lines = list(re.finditer(r'(?m)^HTTP/\S+\s+\d{3}(?:\s+[^\n]*)?$', normalized))
+    if not status_lines:
+        raise GlabApiError("glab api response did not include an HTTP status line")
+    # Start at the final response's status line, then split at that header block's
+    # first blank line. This keeps blank lines in pretty-printed JSON bodies intact.
+    final_response = normalized[status_lines[-1].start():]
+    header_text, sep, body_text = final_response.partition("\n\n")
     if not sep:
         raise GlabApiError("glab api response did not include HTTP headers")
 
-    header_blocks = [block for block in header_text.split("\n\n") if block.strip()]
-    active_headers = header_blocks[-1].splitlines() if header_blocks else []
+    active_headers = header_text.splitlines()
     headers = {}
     for line in active_headers:
         if ":" not in line:
@@ -302,10 +328,10 @@ def _api_get_with_headers(host, endpoint):
 def verify_glab_identity(host):
     """Verify and display the selected GitLab host/account before write workflow calls."""
     user = _api_get(host, "/user")
-    username = (user.get("username") or "").strip() if isinstance(user, dict) else ""
+    username = sanitize_terminal(user.get("username")) if isinstance(user, dict) else ""
     if not username:
         raise GlabApiError("glab /user response did not include a non-empty username")
-    print(f"GitLab host: {get_hostname(host)}")
+    print(f"GitLab host: {sanitize_terminal(get_hostname(host))}")
     print(f"GitLab user: {username}")
     return username
 
@@ -537,7 +563,10 @@ def main():
     try:
         verify_glab_identity(host)
     except Exception as e:
-        print(f"ERROR: Could not verify glab identity: {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not verify glab identity: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     print(f"Fetching current HEAD SHAs for MR !{args.mr}...")
@@ -545,9 +574,12 @@ def main():
         shas = get_mr_versions(host, project_id, args.mr)
         diffs = get_mr_diffs(host, project_id, args.mr)
     except Exception as e:
-        print(f"ERROR: Could not fetch MR metadata/diffs: {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not fetch MR metadata/diffs: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    print(f"  head_sha: {shas['head_sha'][:12]}...")
+    print(f"  head_sha: {sanitize_terminal(shas.get('head_sha'))[:12]}...")
 
     results = []
     for c in comments:
@@ -568,7 +600,7 @@ def main():
                 status = "✅ INLINE"
             else:
                 status = "⚠️  GENERAL (position rejected — check line number)"
-            print(f"  {status} | disc_id: {disc_id}")
+            print(f"  {status} | disc_id: {sanitize_terminal(disc_id)}")
             results.append({
                 "disc_id":              disc_id,
                 "is_inline":            is_inline,
@@ -577,7 +609,7 @@ def main():
                 "line":                 line_number,
             })
         except Exception as e:
-            print(f"  ❌ FAILED: {e}", file=sys.stderr)
+            print(f"  ❌ FAILED: {sanitize_glab_error(str(e))}", file=sys.stderr)
             results.append({"error": str(e), "file": file_path, "line": line_number})
 
     # Summary

--- a/gitlab-cli-skills/scripts/post-inline-comment.py
+++ b/gitlab-cli-skills/scripts/post-inline-comment.py
@@ -72,7 +72,11 @@ VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control
 
 def validate_host(host):
     """Enforce an unambiguous HTTPS host URL before invoking glab."""
-    parsed = urllib.parse.urlparse(host)
+    try:
+        parsed = urllib.parse.urlparse(host)
+    except ValueError:
+        print("ERROR: --host is not a valid URL.", file=sys.stderr)
+        sys.exit(1)
     if parsed.scheme != "https":
         print(
             f"ERROR: --host must use HTTPS (got '{parsed.scheme}://').\n"
@@ -263,7 +267,12 @@ def run_glab_api(host, endpoint, method=None, payload=None, include_headers=Fals
         raise GlabApiError("glab api timed out")
 
     if result.returncode != 0:
-        detail = sanitize_glab_error(result.stderr or result.stdout)
+        # glab writes structured API errors to stdout but may also write a generic
+        # `glab: HTTP 400` status to stderr. Keep stdout first so callers can
+        # inspect validation details such as `line_code` and apply safe retries.
+        detail = sanitize_glab_error("\n".join(
+            part for part in (result.stdout, result.stderr) if part
+        ))
         if detail:
             raise GlabApiError("glab api failed: %s" % detail)
         raise GlabApiError("glab api failed with exit code %s" % result.returncode)

--- a/glab-mr/SKILL.md
+++ b/glab-mr/SKILL.md
@@ -293,53 +293,56 @@ it failed unless you check the returned note's `position` field.
 
 ### The Fix: Always Use JSON Body
 
-Post inline comments via the REST API with a `Content-Type: application/json` body:
+Post inline comments through `glab api` with a literal JSON request body. Keep authentication inside `glab`; never read, copy, log, or print stored token values:
 
-```python
-import json, urllib.request, urllib.parse, subprocess
+```bash
+set -euo pipefail
 
-# Get token from glab config
-token = subprocess.run(
-    ["glab", "config", "get", "token", "--host", "gitlab.com"],
-    capture_output=True, text=True
-).stdout.strip()
+HOST="gitlab.com"
+PROJECT_PATH="mygroup/myproject"
+MR_IID="42"
+FILE_PATH="src/utils/helpers.ts"
+LINE="16"
+BODY="Your comment here"
 
-project = urllib.parse.quote("mygroup/myproject", safe="")
-mr_iid = 42
+# Confirm the exact GitLab host and visible account before creating a discussion.
+glab auth status --hostname "$HOST"
+glab api --hostname "$HOST" /user | jq '{username: .username, name: .name}'
 
-# Always fetch fresh SHAs — never use cached values
-r = urllib.request.urlopen(urllib.request.Request(
-    f"https://gitlab.com/api/v4/projects/{project}/merge_requests/{mr_iid}/versions",
-    headers={"PRIVATE-TOKEN": token}
-))
-v = json.loads(r.read())[0]
+PROJECT_ID="$(python3 -c 'import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "$PROJECT_PATH")"
 
-payload = {
-    "body": "Your comment here",
+# Always fetch fresh SHAs from the current MR version; never use cached values.
+VERSION_JSON="$(glab api --hostname "$HOST" "/projects/$PROJECT_ID/merge_requests/$MR_IID/versions" | jq '.[0]')"
+
+python3 - "$VERSION_JSON" "$FILE_PATH" "$LINE" "$BODY" <<'PY' |
+import json
+import sys
+
+version = json.loads(sys.argv[1])
+file_path = sys.argv[2]
+line = int(sys.argv[3])
+body = sys.argv[4]
+
+json.dump({
+    "body": body,
     "position": {
-        "base_sha":  v["base_commit_sha"],
-        "start_sha": v["start_commit_sha"],
-        "head_sha":  v["head_commit_sha"],
+        "base_sha": version["base_commit_sha"],
+        "start_sha": version["start_commit_sha"],
+        "head_sha": version["head_commit_sha"],
         "position_type": "text",
-        "new_path": "src/utils/helpers.ts",
-        "new_line": 16,
-        "old_path": "src/utils/helpers.ts",  # for renamed files, use the diff's actual old_path
-        "old_line": None                       # None = added line
+        "new_path": file_path,
+        "new_line": line,
+        "old_path": file_path,
+        "old_line": None
     }
-}
-
-req = urllib.request.Request(
-    f"https://gitlab.com/api/v4/projects/{project}/merge_requests/{mr_iid}/discussions",
-    data=json.dumps(payload).encode(),
-    headers={"PRIVATE-TOKEN": token, "Content-Type": "application/json"},
-    method="POST"
-)
-with urllib.request.urlopen(req) as resp:
-    result = json.loads(resp.read())
-    note = result["notes"][0]
-    is_inline = note.get("position") is not None  # True = inline, False = fell back to general
-    print("inline:", is_inline, "| disc_id:", result["id"])
+}, sys.stdout)
+PY
+glab api --hostname "$HOST" --method POST --header "Content-Type: application/json" --input - \
+  "/projects/$PROJECT_ID/merge_requests/$MR_IID/discussions" |
+  jq '{discussion_id: .id, inline: ((.notes[0].position // null) != null)}'
 ```
+
+The returned `inline` value must be `true`. If it is `false`, GitLab created a general discussion and dropped the inline position.
 
 ### Finding the Correct Line Number
 
@@ -401,7 +404,7 @@ Batch file format:
 ]
 ```
 
-The script auto-reads your token from glab config, fetches fresh SHAs and diffs, and uses a two-step anchoring strategy:
+The script lets `glab` handle authentication, fetches fresh SHAs and diffs through `glab api`, and uses a two-step anchoring strategy:
 1. Try the normal `position[new_line]` inline payload first.
 2. If GitLab rejects it with a `line_code` validation error, compute the diff anchor and retry with `position[line_range][start/end][line_code]`.
 

--- a/glab-mr/scripts/post-inline-comment.py
+++ b/glab-mr/scripts/post-inline-comment.py
@@ -38,20 +38,18 @@ BATCH FILE FORMAT (comments.json):
   ]
 
 ENVIRONMENT:
-  GITLAB_TOKEN   — Personal access token with api scope (or set via glab auth login)
   GITLAB_HOST    — GitLab host URL (default: https://gitlab.com)
 
 SECURITY:
-  - Token is read from GITLAB_TOKEN env var or glab config; never logged or echoed
+  - Authentication stays inside glab; this script never reads or prints token values
   - Only HTTPS hosts are accepted (enforced at startup)
   - Comment body is capped at 10,000 characters
   - --project and --file inputs are validated before use
   - Batch files are size-limited (max 100 comments per run)
-  - Token value is validated as non-empty before any API call
 
 REQUIREMENTS:
   - Python 3.6+ (stdlib only, no pip installs needed)
-  - glab authenticated (token auto-read from glab config if GITLAB_TOKEN not set)
+  - glab authenticated (run: glab auth login)
 """
 
 import argparse
@@ -59,74 +57,45 @@ import hashlib
 import json
 import os
 import re
-import ssl
 import subprocess
 import sys
 import urllib.parse
-import urllib.request
-import urllib.error
 
 # ── Security constants ────────────────────────────────────────────────────────
 MAX_BODY_LENGTH = 10_000      # GitLab's own limit is ~1MB but we cap for safety
 MAX_BATCH_SIZE  = 100         # prevent runaway API usage
 MAX_BATCH_FILE_BYTES = 1_048_576  # 1 MB batch file limit
 VALID_PROJECT_RE = re.compile(r'^[\w.\-]+(/[\w.\-]+)+$')  # group/project or group/sub/project
-VALID_FILE_RE    = re.compile(r'^[^\x00\n\r]+$')          # no null bytes or newlines
-
-
-# ── Token handling ────────────────────────────────────────────────────────────
-
-def get_token(host):
-    """
-    Get GitLab token from env or glab config.
-    Never prints or logs the token value.
-    """
-    token = os.environ.get("GITLAB_TOKEN", "").strip()
-    if token:
-        _validate_token(token)
-        return token
-
-    # Derive hostname for glab config lookup
-    hostname = urllib.parse.urlparse(host).hostname or "gitlab.com"
-    try:
-        result = subprocess.run(
-            ["glab", "config", "get", "token", "--host", hostname],
-            capture_output=True, text=True, timeout=10
-        )
-        if result.returncode == 0:
-            token = result.stdout.strip()
-            if token:
-                _validate_token(token)
-                return token
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
-
-    print(
-        "ERROR: No GitLab token found.\n"
-        "  Set the GITLAB_TOKEN environment variable, or run: glab auth login",
-        file=sys.stderr
-    )
-    sys.exit(1)
-
-
-def _validate_token(token):
-    """Basic sanity check — token must look like a PAT (non-empty, no whitespace)."""
-    if not token or len(token) < 10 or re.search(r'\s', token):
-        print("ERROR: GITLAB_TOKEN appears invalid (too short or contains whitespace).", file=sys.stderr)
-        sys.exit(1)
-
+VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control characters
 
 # ── Input validation ──────────────────────────────────────────────────────────
 
 def validate_host(host):
-    """Enforce HTTPS to prevent token leakage over plaintext."""
+    """Enforce an unambiguous HTTPS host URL before invoking glab."""
     parsed = urllib.parse.urlparse(host)
     if parsed.scheme != "https":
         print(
             f"ERROR: --host must use HTTPS (got '{parsed.scheme}://').\n"
-            "  Token transmission over HTTP is not allowed.",
+            "  Credential transmission over HTTP is not allowed.",
             file=sys.stderr
         )
+        sys.exit(1)
+    if not parsed.netloc:
+        print("ERROR: --host must include a hostname.", file=sys.stderr)
+        sys.exit(1)
+    if parsed.username or parsed.password:
+        print("ERROR: --host must not include username or password information.", file=sys.stderr)
+        sys.exit(1)
+    try:
+        port = parsed.port
+    except ValueError:
+        print("ERROR: --host contains an invalid port.", file=sys.stderr)
+        sys.exit(1)
+    if port not in (None, 443):
+        print("ERROR: --host must use the standard HTTPS port because glab --hostname does not accept ports.", file=sys.stderr)
+        sys.exit(1)
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        print("ERROR: --host must be only an HTTPS scheme and host, with no path, query, or fragment.", file=sys.stderr)
         sys.exit(1)
     return host.rstrip("/")
 
@@ -214,32 +183,128 @@ def load_batch_file(path):
     return validated
 
 
-# ── GitLab API helpers ────────────────────────────────────────────────────────
+# ── glab API helpers ──────────────────────────────────────────────────────────
 
-def _make_ssl_context():
-    """Return a strict SSL context (system CA bundle, no hostname bypass)."""
-    ctx = ssl.create_default_context()
-    return ctx
+class GlabApiError(RuntimeError):
+    """Raised when a glab api call fails."""
 
 
-def _api_get(token, url):
+def get_hostname(host):
+    """Return the hostname that glab should use for an already-validated host URL."""
+    parsed = urllib.parse.urlparse(host)
+    return parsed.hostname or "gitlab.com"
+
+
+def sanitize_glab_error(text, limit=500):
+    """Bound and redact glab stderr/stdout before showing it to a user."""
+    text = text or ""
+    text = re.sub(r'\x1b\][^\x07]*(?:\x07|\x1b\\)', '', text)
+    text = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', text)
+    text = ''.join(
+        char for char in text
+        if char in "\n\t" or 0x20 <= ord(char) < 0x7f or ord(char) >= 0xa0
+    )
+    text = re.sub(
+        r'(?im)^(\s*>?\s*)(Authorization|PRIVATE-TOKEN|JOB-TOKEN|OAUTH-TOKEN)\s*:.*$',
+        lambda match: "%s%s: [REDACTED]" % (match.group(1), match.group(2)),
+        text,
+    )
+    text = re.sub(r'glpat-[A-Za-z0-9_\-]+', 'glpat-[REDACTED]', text)
+    text = re.sub(r'(?i)(PRIVATE-TOKEN|Authorization|Bearer|token)([=: ]+)(\S+)', r'\1\2[REDACTED]', text)
+    text = text.replace("\r", "\n").strip()
+    if len(text) > limit:
+        text = text[:limit] + "...(truncated)"
+    return text
+
+
+def parse_included_response(output):
+    """Parse `glab api --include` output into (JSON body, response headers)."""
+    normalized = output.replace("\r\n", "\n")
+    header_text, sep, body_text = normalized.rpartition("\n\n")
+    if not sep:
+        raise GlabApiError("glab api response did not include HTTP headers")
+
+    header_blocks = [block for block in header_text.split("\n\n") if block.strip()]
+    active_headers = header_blocks[-1].splitlines() if header_blocks else []
+    headers = {}
+    for line in active_headers:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+    return json.loads(body_text), headers
+
+
+def run_glab_api(host, endpoint, method=None, payload=None, include_headers=False):
+    """Run an authenticated GitLab API call through glab without reading credentials."""
+    args = ["glab", "api", "--hostname", get_hostname(host)]
+    if include_headers:
+        args.append("--include")
+    if method:
+        args.extend(["--method", method])
+    input_text = None
+    if payload is not None:
+        args.extend(["--header", "Content-Type: application/json", "--input", "-"])
+        input_text = json.dumps(payload)
+    args.append(endpoint)
+
+    try:
+        result = subprocess.run(
+            args,
+            input=input_text,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        raise GlabApiError("glab executable not found. Install glab and run: glab auth login")
+    except subprocess.TimeoutExpired:
+        raise GlabApiError("glab api timed out")
+
+    if result.returncode != 0:
+        detail = sanitize_glab_error(result.stderr or result.stdout)
+        if detail:
+            raise GlabApiError("glab api failed: %s" % detail)
+        raise GlabApiError("glab api failed with exit code %s" % result.returncode)
+
+    if include_headers:
+        try:
+            return parse_included_response(result.stdout)
+        except (json.JSONDecodeError, GlabApiError) as e:
+            raise GlabApiError("Could not parse glab api response: %s" % e)
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise GlabApiError("Could not parse glab api JSON response: %s" % e)
+
+
+def _api_get(host, endpoint):
     """Authenticated GET request, returns parsed JSON."""
-    req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": token})
-    with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-        return json.loads(resp.read())
+    return run_glab_api(host, endpoint)
 
 
-def _api_get_with_headers(token, url):
+def _api_get_with_headers(host, endpoint):
     """Authenticated GET request, returns (parsed_json, headers)."""
-    req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": token})
-    with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-        return json.loads(resp.read()), resp.headers
+    return run_glab_api(host, endpoint, include_headers=True)
 
 
-def get_mr_versions(token, host, project_id, mr_iid):
+def verify_glab_identity(host):
+    """Verify and display the selected GitLab host/account before write workflow calls."""
+    user = _api_get(host, "/user")
+    username = (user.get("username") or "").strip() if isinstance(user, dict) else ""
+    if not username:
+        raise GlabApiError("glab /user response did not include a non-empty username")
+    print(f"GitLab host: {get_hostname(host)}")
+    print(f"GitLab user: {username}")
+    return username
+
+
+def get_mr_versions(host, project_id, mr_iid):
     """Fetch current HEAD/START/BASE SHAs for an MR."""
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/versions"
-    versions = _api_get(token, url)
+    endpoint = f"/projects/{project_id}/merge_requests/{mr_iid}/versions"
+    versions = _api_get(host, endpoint)
     if not versions:
         raise ValueError(f"No versions found for MR !{mr_iid}")
     latest = versions[0]
@@ -250,20 +315,20 @@ def get_mr_versions(token, host, project_id, mr_iid):
     }
 
 
-def get_mr_diffs(token, host, project_id, mr_iid):
+def get_mr_diffs(host, project_id, mr_iid):
     """Fetch all MR diffs so we can compute line_code anchors when GitLab requires them."""
     diffs = []
     page = 1
 
     while True:
-        url = (
-            f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/diffs"
+        endpoint = (
+            f"/projects/{project_id}/merge_requests/{mr_iid}/diffs"
             f"?per_page=100&page={page}"
         )
-        page_diffs, headers = _api_get_with_headers(token, url)
+        page_diffs, headers = _api_get_with_headers(host, endpoint)
         diffs.extend(page_diffs)
 
-        next_page = (headers.get("X-Next-Page") or "").strip()
+        next_page = (headers.get("x-next-page") or "").strip()
         if not next_page:
             break
         page = int(next_page)
@@ -386,43 +451,26 @@ def build_line_range_payload(shas, diff_entry, file_path, body, anchor):
     }
 
 
-def post_discussion(token, url, payload):
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={
-            "PRIVATE-TOKEN": token,
-            "Content-Type":  "application/json",
-        },
-        method="POST"
-    )
-
-    try:
-        with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        error_body = e.read().decode(errors="replace")
-        raise RuntimeError(f"HTTP {e.code}: {error_body[:500]}")
+def post_discussion(host, project_id, mr_iid, payload):
+    endpoint = f"/projects/{project_id}/merge_requests/{mr_iid}/discussions"
+    return run_glab_api(host, endpoint, method="POST", payload=payload)
 
 
 def is_line_code_validation_error(error_text):
     return "line_code" in error_text and "valid" in error_text.lower()
 
 
-def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path, line_number, body):
+def post_inline_comment(host, project_id, mr_iid, shas, diffs, file_path, line_number, body):
     """
     Post a single inline comment on a MR diff using a JSON body.
     First try the simple new_line payload; if GitLab rejects it with a line_code
     validation error, compute the diff anchor and retry with position.line_range.
     Returns (disc_id, is_inline, used_line_code_retry) tuple.
     """
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions"
-
     diff_entry = find_file_diff(diffs, file_path)
 
     try:
-        r = post_discussion(token, url, build_inline_payload(shas, diff_entry, file_path, line_number, body))
+        r = post_discussion(host, project_id, mr_iid, build_inline_payload(shas, diff_entry, file_path, line_number, body))
         used_line_code_retry = False
     except Exception as e:
         error_text = str(e)
@@ -431,7 +479,7 @@ def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path,
 
         anchor = compute_diff_anchor(diff_entry.get("diff", ""), line_number)
         retry_payload = build_line_range_payload(shas, diff_entry, file_path, body, anchor)
-        r = post_discussion(token, url, retry_payload)
+        r = post_discussion(host, project_id, mr_iid, retry_payload)
         used_line_code_retry = True
 
     note = r.get("notes", [{}])[0]
@@ -477,13 +525,16 @@ def main():
             "body": validate_body(args.body),
         }]
 
-    # Fetch token after validation (avoids unnecessary credential access on bad input)
-    token = get_token(host)
+    try:
+        verify_glab_identity(host)
+    except Exception as e:
+        print(f"ERROR: Could not verify glab identity: {e}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Fetching current HEAD SHAs for MR !{args.mr}...")
     try:
-        shas = get_mr_versions(token, host, project_id, args.mr)
-        diffs = get_mr_diffs(token, host, project_id, args.mr)
+        shas = get_mr_versions(host, project_id, args.mr)
+        diffs = get_mr_diffs(host, project_id, args.mr)
     except Exception as e:
         print(f"ERROR: Could not fetch MR metadata/diffs: {e}", file=sys.stderr)
         sys.exit(1)
@@ -496,11 +547,11 @@ def main():
         body        = c["body"]
 
         print(f"\nPosting: {file_path}:{line_number}")
-        print(f"  Body: {body[:80]}{'...' if len(body) > 80 else ''}")
+        print(f"  Body length: {len(body)} characters")
 
         try:
             disc_id, is_inline, used_line_code_retry = post_inline_comment(
-                token, host, project_id, args.mr, shas, diffs, file_path, line_number, body
+                host, project_id, args.mr, shas, diffs, file_path, line_number, body
             )
             if is_inline and used_line_code_retry:
                 status = "✅ INLINE (line_code retry)"

--- a/glab-mr/scripts/post-inline-comment.py
+++ b/glab-mr/scripts/post-inline-comment.py
@@ -60,13 +60,19 @@ import re
 import subprocess
 import sys
 import urllib.parse
+from typing import Optional
 
 # ── Security constants ────────────────────────────────────────────────────────
 MAX_BODY_LENGTH = 10_000      # GitLab's own limit is ~1MB but we cap for safety
 MAX_BATCH_SIZE  = 100         # prevent runaway API usage
 MAX_BATCH_FILE_BYTES = 1_048_576  # 1 MB batch file limit
-VALID_PROJECT_RE = re.compile(r'^[\w.\-]+(/[\w.\-]+)+$')  # group/project or group/sub/project
-VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control characters
+VALID_PROJECT_RE = re.compile(r'[\w.\-]+(/[\w.\-]+)+')  # group/project or group/sub/project
+VALID_FILE_RE    = re.compile(
+    r'[^\x00-\x1f\x7f-\x9f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]+'
+)  # no terminal or bidirectional control characters
+BIDI_CONTROL_CHARS = frozenset(
+    "\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+)
 
 # ── Input validation ──────────────────────────────────────────────────────────
 
@@ -106,9 +112,9 @@ def validate_host(host):
 
 def validate_project(project):
     """Validate project path format: group/project or group/subgroup/project."""
-    if not VALID_PROJECT_RE.match(project):
+    if not VALID_PROJECT_RE.fullmatch(project):
         print(
-            f"ERROR: --project '{project}' is not a valid GitLab project path.\n"
+            f"ERROR: --project {project!r} is not a valid GitLab project path.\n"
             "  Expected format: 'group/project' or 'group/subgroup/project'",
             file=sys.stderr
         )
@@ -118,7 +124,7 @@ def validate_project(project):
 
 def validate_file_path(file_path):
     """Validate that a file path doesn't contain dangerous characters."""
-    if not file_path or not VALID_FILE_RE.match(file_path):
+    if not file_path or not VALID_FILE_RE.fullmatch(file_path):
         print(f"ERROR: Invalid file path: {repr(file_path)}", file=sys.stderr)
         sys.exit(1)
     return file_path
@@ -160,7 +166,10 @@ def load_batch_file(path):
         with open(path) as f:
             comments = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
-        print(f"ERROR: Could not load batch file '{path}': {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not load batch file {path!r}: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     if not isinstance(comments, list):
@@ -199,15 +208,28 @@ def get_hostname(host):
     return parsed.hostname or "gitlab.com"
 
 
-def sanitize_glab_error(text, limit=500):
-    """Bound and redact glab stderr/stdout before showing it to a user."""
-    text = text or ""
+def sanitize_terminal(text, limit: Optional[int] = 500, multiline=False):
+    """Remove terminal controls from untrusted text before displaying it."""
+    text = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
     text = re.sub(r'\x1b\][^\x07]*(?:\x07|\x1b\\)', '', text)
     text = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', text)
     text = ''.join(
         char for char in text
-        if char in "\n\t" or 0x20 <= ord(char) < 0x7f or ord(char) >= 0xa0
+        if char not in BIDI_CONTROL_CHARS and (
+            (multiline and char in "\n\t")
+            or 0x20 <= ord(char) < 0x7f
+            or ord(char) >= 0xa0
+        )
     )
+    text = text.strip()
+    if limit is not None and len(text) > limit:
+        text = text[:limit] + "...(truncated)"
+    return text
+
+
+def sanitize_glab_error(text, limit=500):
+    """Bound and redact glab stderr/stdout before showing it to a user."""
+    text = sanitize_terminal(text, limit=None, multiline=True)
     text = re.sub(
         r'(?im)^(\s*>?\s*)(Authorization|PRIVATE-TOKEN|JOB-TOKEN|OAUTH-TOKEN)\s*:.*$',
         lambda match: "%s%s: [REDACTED]" % (match.group(1), match.group(2)),
@@ -215,7 +237,6 @@ def sanitize_glab_error(text, limit=500):
     )
     text = re.sub(r'glpat-[A-Za-z0-9_\-]+', 'glpat-[REDACTED]', text)
     text = re.sub(r'(?i)(PRIVATE-TOKEN|Authorization|Bearer|token)([=: ]+)(\S+)', r'\1\2[REDACTED]', text)
-    text = text.replace("\r", "\n").strip()
     if len(text) > limit:
         text = text[:limit] + "...(truncated)"
     return text
@@ -224,12 +245,17 @@ def sanitize_glab_error(text, limit=500):
 def parse_included_response(output):
     """Parse `glab api --include` output into (JSON body, response headers)."""
     normalized = output.replace("\r\n", "\n")
-    header_text, sep, body_text = normalized.rpartition("\n\n")
+    status_lines = list(re.finditer(r'(?m)^HTTP/\S+\s+\d{3}(?:\s+[^\n]*)?$', normalized))
+    if not status_lines:
+        raise GlabApiError("glab api response did not include an HTTP status line")
+    # Start at the final response's status line, then split at that header block's
+    # first blank line. This keeps blank lines in pretty-printed JSON bodies intact.
+    final_response = normalized[status_lines[-1].start():]
+    header_text, sep, body_text = final_response.partition("\n\n")
     if not sep:
         raise GlabApiError("glab api response did not include HTTP headers")
 
-    header_blocks = [block for block in header_text.split("\n\n") if block.strip()]
-    active_headers = header_blocks[-1].splitlines() if header_blocks else []
+    active_headers = header_text.splitlines()
     headers = {}
     for line in active_headers:
         if ":" not in line:
@@ -302,10 +328,10 @@ def _api_get_with_headers(host, endpoint):
 def verify_glab_identity(host):
     """Verify and display the selected GitLab host/account before write workflow calls."""
     user = _api_get(host, "/user")
-    username = (user.get("username") or "").strip() if isinstance(user, dict) else ""
+    username = sanitize_terminal(user.get("username")) if isinstance(user, dict) else ""
     if not username:
         raise GlabApiError("glab /user response did not include a non-empty username")
-    print(f"GitLab host: {get_hostname(host)}")
+    print(f"GitLab host: {sanitize_terminal(get_hostname(host))}")
     print(f"GitLab user: {username}")
     return username
 
@@ -537,7 +563,10 @@ def main():
     try:
         verify_glab_identity(host)
     except Exception as e:
-        print(f"ERROR: Could not verify glab identity: {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not verify glab identity: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     print(f"Fetching current HEAD SHAs for MR !{args.mr}...")
@@ -545,9 +574,12 @@ def main():
         shas = get_mr_versions(host, project_id, args.mr)
         diffs = get_mr_diffs(host, project_id, args.mr)
     except Exception as e:
-        print(f"ERROR: Could not fetch MR metadata/diffs: {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not fetch MR metadata/diffs: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    print(f"  head_sha: {shas['head_sha'][:12]}...")
+    print(f"  head_sha: {sanitize_terminal(shas.get('head_sha'))[:12]}...")
 
     results = []
     for c in comments:
@@ -568,7 +600,7 @@ def main():
                 status = "✅ INLINE"
             else:
                 status = "⚠️  GENERAL (position rejected — check line number)"
-            print(f"  {status} | disc_id: {disc_id}")
+            print(f"  {status} | disc_id: {sanitize_terminal(disc_id)}")
             results.append({
                 "disc_id":              disc_id,
                 "is_inline":            is_inline,
@@ -577,7 +609,7 @@ def main():
                 "line":                 line_number,
             })
         except Exception as e:
-            print(f"  ❌ FAILED: {e}", file=sys.stderr)
+            print(f"  ❌ FAILED: {sanitize_glab_error(str(e))}", file=sys.stderr)
             results.append({"error": str(e), "file": file_path, "line": line_number})
 
     # Summary

--- a/glab-mr/scripts/post-inline-comment.py
+++ b/glab-mr/scripts/post-inline-comment.py
@@ -72,7 +72,11 @@ VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control
 
 def validate_host(host):
     """Enforce an unambiguous HTTPS host URL before invoking glab."""
-    parsed = urllib.parse.urlparse(host)
+    try:
+        parsed = urllib.parse.urlparse(host)
+    except ValueError:
+        print("ERROR: --host is not a valid URL.", file=sys.stderr)
+        sys.exit(1)
     if parsed.scheme != "https":
         print(
             f"ERROR: --host must use HTTPS (got '{parsed.scheme}://').\n"
@@ -263,7 +267,12 @@ def run_glab_api(host, endpoint, method=None, payload=None, include_headers=Fals
         raise GlabApiError("glab api timed out")
 
     if result.returncode != 0:
-        detail = sanitize_glab_error(result.stderr or result.stdout)
+        # glab writes structured API errors to stdout but may also write a generic
+        # `glab: HTTP 400` status to stderr. Keep stdout first so callers can
+        # inspect validation details such as `line_code` and apply safe retries.
+        detail = sanitize_glab_error("\n".join(
+            part for part in (result.stdout, result.stderr) if part
+        ))
         if detail:
             raise GlabApiError("glab api failed: %s" % detail)
         raise GlabApiError("glab api failed with exit code %s" % result.returncode)

--- a/scripts/README-inline-comments.md
+++ b/scripts/README-inline-comments.md
@@ -124,25 +124,30 @@ Example `comments.json`:
 ### Success Output
 
 ```
-✅ Success!
-Discussion ID: abc123...
-Note ID: 3106970438
-Note Type: DiffNote
-Inline: true
+GitLab host: gitlab.example.com
+GitLab user: reviewer
+Fetching current HEAD SHAs for MR !42...
+  head_sha: 0123456789ab...
 
-✅ Inline comment posted successfully at src/main.js:42
-URL: https://gitlab.com/owner/repo/-/merge_requests/42#note_3106970438
+Posting: src/main.js:42
+  Body length: 26 characters
+  ✅ INLINE (line_code retry) | disc_id: abc123
+
+==================================================
+Summary: 1 inline ✅  1 retried-with-line_code 🔁  0 general ⚠️  0 failed ❌
+
+Discussion IDs: ["abc123"]
 ```
 
-The script also outputs the full JSON response for programmatic use.
+The helper emits human-readable status and a final JSON array of discussion IDs; it does not print the full API response or raw comment bodies.
 
 ### Error Output
 
 ```
-❌ Error: HTTP 400
-{
-  "message": "400 Bad request - Position is invalid"
-}
+  ❌ FAILED: glab api failed: {"message":{"position":["Position is invalid"]}}
+
+==================================================
+Summary: 0 inline ✅  0 retried-with-line_code 🔁  0 general ⚠️  1 failed ❌
 ```
 
 Common errors:

--- a/scripts/README-inline-comments.md
+++ b/scripts/README-inline-comments.md
@@ -8,7 +8,7 @@ The `post-inline-comment.py` helper posts inline code review comments to GitLab 
 
 **Problem:** GitLab's native `glab mr note` command only creates general MR comments. When reviewing code, you often want to comment on specific lines, but there's no built-in glab command for this.
 
-**Solution:** This script uses the GitLab Discussions API to post inline comments with proper position data (file path, line number, and commit SHAs).
+**Solution:** This script uses `glab api` to call the GitLab Discussions API with proper JSON position data (file path, line number, and commit SHAs). Authentication stays inside `glab`; the helper never reads token values.
 
 **Benefits:**
 - 📍 **Contextualized feedback** - Comments appear at exact line locations
@@ -87,15 +87,16 @@ Example `comments.json`:
 
 ## How It Works
 
-1. **Reads the GitLab token** from `GITLAB_TOKEN` or glab config
-2. **Fetches MR metadata and all diff pages** to get:
+1. **Uses `glab api` for authenticated requests** with normal `glab` auth and environment precedence, without reading token values
+2. **Verifies the selected host/account** with a read-only `/user` request and prints the hostname and username before any discussion write
+3. **Fetches MR metadata and all diff pages** to get:
    - Project ID
    - Base SHA (target branch commit)
    - Head SHA (source branch commit)
    - Start SHA (merge base commit)
    - Raw file diff text for anchor recovery
    - Actual `old_path` / `new_path` values for renamed-file anchors
-3. **Builds JSON payload** with position data:
+4. **Builds JSON payload** with position data:
    ```json
    {
      "body": "Comment text",
@@ -109,14 +110,14 @@ Example `comments.json`:
      }
    }
    ```
-4. **Posts to GitLab API** with a JSON body
-5. **If GitLab rejects the simple payload with a `line_code` validation error**:
+5. **Posts to GitLab API through `glab api --input -`** with a literal JSON body
+6. **If GitLab rejects the simple payload with a `line_code` validation error**:
    - Parse the file diff
    - Derive the correct old/new diff line pair for the target line
    - Compute `sha1(diff_path) + '_' + oldLine + '_' + newLine`
    - Retry using `position[line_range][start/end][line_code]`
    - Reuse the diff's actual `old_path` / `new_path` when the file was renamed
-6. **Validates response** - Checks that note type is `DiffNote` (inline) not `DiscussionNote` (general)
+7. **Validates response** - Checks that the returned discussion note has a non-null `position` (inline) rather than a general discussion
 
 ## Output
 
@@ -146,14 +147,14 @@ The script also outputs the full JSON response for programmatic use.
 
 Common errors:
 - **400 Bad Request** - Line number doesn't exist in diff
-- **401 Unauthorized** - Token invalid or expired
+- **401 Unauthorized** - `glab` is not authenticated for the selected host, or its configured credentials are expired
 - **404 Not Found** - MR or repo doesn't exist
 
 ## Troubleshooting
 
-### "Could not extract GitLab token"
+### `glab` authentication errors
 
-**Cause:** glab CLI not authenticated or config file missing.
+**Cause:** `glab` is not authenticated for the selected host, or the visible account does not have access to the project/MR.
 
 **Fix:**
 ```bash
@@ -237,7 +238,7 @@ done
 1. **Line must exist in diff** - Can only comment on lines that were added or changed in the MR
 2. **File path must be exact** - Must match the path relative to repo root exactly
 3. **New file lines only** - Line number refers to the NEW version (after changes)
-4. **GitLab.com only** - Script uses `https://gitlab.com/api/v4/` (modify for self-hosted)
+4. **HTTPS host roots only** - Use `--host https://gitlab.example.com` for self-hosted instances. Userinfo, paths, query strings, fragments, and non-default ports are rejected because `glab api --hostname` does not accept a port.
 
 ## API Reference
 

--- a/scripts/add-inline-comment.sh
+++ b/scripts/add-inline-comment.sh
@@ -1,141 +1,35 @@
-#!/bin/bash
-# add-inline-comment.sh
-# Post inline code review comments to GitLab MRs at specific line numbers
-# Part of: gitlab-cli-skills
-# 
+#!/usr/bin/env bash
+# Compatibility wrapper for the JSON-body inline comment helper.
+#
 # Usage: add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
-# Example: add-inline-comment.sh owner/repo 42 "src/File.js" 100 "Bug: This needs fixing"
 
-set -e
+set -euo pipefail
 
-# Color codes for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-if [ $# -lt 5 ]; then
-    echo -e "${RED}Usage: $0 <repo> <mr_iid> <file_path> <line_number> <comment_text>${NC}" >&2
-    echo "" >&2
-    echo "Arguments:" >&2
-    echo "  repo           Repository path (e.g., 'owner/repo')" >&2
-    echo "  mr_iid         Merge request IID (numeric ID)" >&2
-    echo "  file_path      Path to file relative to repo root" >&2
-    echo "  line_number    Line number in the NEW version of the file" >&2
-    echo "  comment_text   Comment text (supports markdown)" >&2
-    echo "" >&2
-    echo "Example:" >&2
-    echo "  $0 owner/repo 42 \"src/main.js\" 100 \"Bug: Add null check here\"" >&2
-    exit 1
+if [ "$#" -lt 5 ]; then
+  echo "Usage: $0 <repo> <mr_iid> <file_path> <line_number> <comment_text>" >&2
+  echo "Example: $0 owner/repo 42 \"src/main.js\" 100 \"Bug: Add null check here\"" >&2
+  exit 1
 fi
 
 REPO="$1"
 MR_IID="$2"
 FILE_PATH="$3"
 LINE_NUMBER="$4"
-COMMENT_TEXT="$5"
+shift 4
+COMMENT_TEXT="$*"
 
-# URL-encode the repo path
-REPO_ENCODED=$(echo "$REPO" | sed 's/\//%2F/g')
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOST="${GITLAB_HOST:-https://gitlab.com}"
+case "$HOST" in
+  https://*) ;;
+  http://*) ;;
+  *) HOST="https://$HOST" ;;
+esac
 
-# Retrieve GitLab token via glab (avoids direct access to credential files)
-GITLAB_TOKEN=$(glab auth token 2>/dev/null)
-
-if [ -z "$GITLAB_TOKEN" ]; then
-    echo -e "${RED}Error: Could not retrieve GitLab token${NC}" >&2
-    echo "Make sure you're authenticated with: glab auth login" >&2
-    exit 1
-fi
-
-# Get MR metadata to extract project ID and SHAs
-echo -e "${YELLOW}Fetching MR metadata...${NC}" >&2
-MR_DATA=$(glab api "/projects/$REPO_ENCODED/merge_requests/$MR_IID" 2>&1)
-
-if [ $? -ne 0 ]; then
-    echo -e "${RED}Error: Could not fetch MR metadata${NC}" >&2
-    echo "$MR_DATA" >&2
-    exit 1
-fi
-
-PROJECT_ID=$(echo "$MR_DATA" | jq -r '.project_id')
-BASE_SHA=$(echo "$MR_DATA" | jq -r '.diff_refs.base_sha')
-HEAD_SHA=$(echo "$MR_DATA" | jq -r '.diff_refs.head_sha')
-START_SHA=$(echo "$MR_DATA" | jq -r '.diff_refs.start_sha')
-
-if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
-    echo -e "${RED}Error: Could not get project ID from MR${NC}" >&2
-    exit 1
-fi
-
-if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "null" ]; then
-    echo -e "${RED}Error: Could not get SHAs from MR diff_refs${NC}" >&2
-    exit 1
-fi
-
-echo -e "${YELLOW}Project ID: $PROJECT_ID${NC}" >&2
-echo -e "${YELLOW}Base SHA: ${BASE_SHA:0:8}...${NC}" >&2
-echo -e "${YELLOW}Head SHA: ${HEAD_SHA:0:8}...${NC}" >&2
-echo -e "${YELLOW}Target: $FILE_PATH:$LINE_NUMBER${NC}" >&2
-
-# Escape JSON special characters in comment text
-COMMENT_ESCAPED=$(echo "$COMMENT_TEXT" | jq -Rs .)
-
-# Build JSON payload
-JSON_PAYLOAD=$(cat <<EOF
-{
-  "body": $COMMENT_ESCAPED,
-  "position": {
-    "base_sha": "$BASE_SHA",
-    "start_sha": "$START_SHA",
-    "head_sha": "$HEAD_SHA",
-    "position_type": "text",
-    "new_path": "$FILE_PATH",
-    "new_line": $LINE_NUMBER
-  }
-}
-EOF
-)
-
-# Post inline comment
-echo -e "${YELLOW}Posting inline comment...${NC}" >&2
-RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-    "https://gitlab.com/api/v4/projects/$PROJECT_ID/merge_requests/$MR_IID/discussions" \
-    -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d "$JSON_PAYLOAD")
-
-HTTP_CODE=$(echo "$RESPONSE" | tail -n 1)
-BODY=$(echo "$RESPONSE" | sed '$d')
-
-if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
-    DISCUSSION_ID=$(echo "$BODY" | jq -r '.id')
-    NOTE_ID=$(echo "$BODY" | jq -r '.notes[0].id')
-    HAS_POSITION=$(echo "$BODY" | jq -r '.notes[0].position != null')
-    NOTE_TYPE=$(echo "$BODY" | jq -r '.notes[0].type')
-    
-    echo "" >&2
-    echo -e "${GREEN}✅ Success!${NC}" >&2
-    echo -e "${GREEN}Discussion ID: $DISCUSSION_ID${NC}" >&2
-    echo -e "${GREEN}Note ID: $NOTE_ID${NC}" >&2
-    echo -e "${GREEN}Note Type: $NOTE_TYPE${NC}" >&2
-    echo -e "${GREEN}Inline: $HAS_POSITION${NC}" >&2
-    
-    if [ "$NOTE_TYPE" = "DiffNote" ] && [ "$HAS_POSITION" = "true" ]; then
-        echo "" >&2
-        echo -e "${GREEN}✅ Inline comment posted successfully at $FILE_PATH:$LINE_NUMBER${NC}" >&2
-        echo -e "${GREEN}URL: https://gitlab.com/$REPO/-/merge_requests/$MR_IID#note_$NOTE_ID${NC}" >&2
-    else
-        echo "" >&2
-        echo -e "${YELLOW}⚠️  Warning: Comment was posted but may not be inline${NC}" >&2
-        echo -e "${YELLOW}   Type: $NOTE_TYPE (expected: DiffNote)${NC}" >&2
-        echo -e "${YELLOW}   Has position: $HAS_POSITION (expected: true)${NC}" >&2
-    fi
-    
-    # Output JSON for programmatic use
-    echo "$BODY"
-else
-    echo "" >&2
-    echo -e "${RED}❌ Error: HTTP $HTTP_CODE${NC}" >&2
-    echo "$BODY" | jq . >&2
-    exit 1
-fi
+exec python3 "$SCRIPT_DIR/post-inline-comment.py" \
+  --host "$HOST" \
+  --project "$REPO" \
+  --mr "$MR_IID" \
+  --file "$FILE_PATH" \
+  --line "$LINE_NUMBER" \
+  --body "$COMMENT_TEXT"

--- a/scripts/add-inline-comment.sh
+++ b/scripts/add-inline-comment.sh
@@ -2,10 +2,11 @@
 # Compatibility wrapper for the JSON-body inline comment helper.
 #
 # Usage: add-inline-comment.sh <repo> <mr_iid> <file_path> <line_number> <comment_text>
+# Pass comment_text as one quoted fifth argument.
 
 set -euo pipefail
 
-if [ "$#" -lt 5 ]; then
+if [ "$#" -ne 5 ]; then
   echo "Usage: $0 <repo> <mr_iid> <file_path> <line_number> <comment_text>" >&2
   echo "Example: $0 owner/repo 42 \"src/main.js\" 100 \"Bug: Add null check here\"" >&2
   exit 1
@@ -15,8 +16,7 @@ REPO="$1"
 MR_IID="$2"
 FILE_PATH="$3"
 LINE_NUMBER="$4"
-shift 4
-COMMENT_TEXT="$*"
+COMMENT_TEXT="$5"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOST="${GITLAB_HOST:-https://gitlab.com}"

--- a/scripts/post-inline-comment.py
+++ b/scripts/post-inline-comment.py
@@ -38,20 +38,18 @@ BATCH FILE FORMAT (comments.json):
   ]
 
 ENVIRONMENT:
-  GITLAB_TOKEN   — Personal access token with api scope (or set via glab auth login)
   GITLAB_HOST    — GitLab host URL (default: https://gitlab.com)
 
 SECURITY:
-  - Token is read from GITLAB_TOKEN env var or glab config; never logged or echoed
+  - Authentication stays inside glab; this script never reads or prints token values
   - Only HTTPS hosts are accepted (enforced at startup)
   - Comment body is capped at 10,000 characters
   - --project and --file inputs are validated before use
   - Batch files are size-limited (max 100 comments per run)
-  - Token value is validated as non-empty before any API call
 
 REQUIREMENTS:
   - Python 3.6+ (stdlib only, no pip installs needed)
-  - glab authenticated (token auto-read from glab config if GITLAB_TOKEN not set)
+  - glab authenticated (run: glab auth login)
 """
 
 import argparse
@@ -59,74 +57,45 @@ import hashlib
 import json
 import os
 import re
-import ssl
 import subprocess
 import sys
 import urllib.parse
-import urllib.request
-import urllib.error
 
 # ── Security constants ────────────────────────────────────────────────────────
 MAX_BODY_LENGTH = 10_000      # GitLab's own limit is ~1MB but we cap for safety
 MAX_BATCH_SIZE  = 100         # prevent runaway API usage
 MAX_BATCH_FILE_BYTES = 1_048_576  # 1 MB batch file limit
 VALID_PROJECT_RE = re.compile(r'^[\w.\-]+(/[\w.\-]+)+$')  # group/project or group/sub/project
-VALID_FILE_RE    = re.compile(r'^[^\x00\n\r]+$')          # no null bytes or newlines
-
-
-# ── Token handling ────────────────────────────────────────────────────────────
-
-def get_token(host):
-    """
-    Get GitLab token from env or glab config.
-    Never prints or logs the token value.
-    """
-    token = os.environ.get("GITLAB_TOKEN", "").strip()
-    if token:
-        _validate_token(token)
-        return token
-
-    # Derive hostname for glab config lookup
-    hostname = urllib.parse.urlparse(host).hostname or "gitlab.com"
-    try:
-        result = subprocess.run(
-            ["glab", "config", "get", "token", "--host", hostname],
-            capture_output=True, text=True, timeout=10
-        )
-        if result.returncode == 0:
-            token = result.stdout.strip()
-            if token:
-                _validate_token(token)
-                return token
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
-
-    print(
-        "ERROR: No GitLab token found.\n"
-        "  Set the GITLAB_TOKEN environment variable, or run: glab auth login",
-        file=sys.stderr
-    )
-    sys.exit(1)
-
-
-def _validate_token(token):
-    """Basic sanity check — token must look like a PAT (non-empty, no whitespace)."""
-    if not token or len(token) < 10 or re.search(r'\s', token):
-        print("ERROR: GITLAB_TOKEN appears invalid (too short or contains whitespace).", file=sys.stderr)
-        sys.exit(1)
-
+VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control characters
 
 # ── Input validation ──────────────────────────────────────────────────────────
 
 def validate_host(host):
-    """Enforce HTTPS to prevent token leakage over plaintext."""
+    """Enforce an unambiguous HTTPS host URL before invoking glab."""
     parsed = urllib.parse.urlparse(host)
     if parsed.scheme != "https":
         print(
             f"ERROR: --host must use HTTPS (got '{parsed.scheme}://').\n"
-            "  Token transmission over HTTP is not allowed.",
+            "  Credential transmission over HTTP is not allowed.",
             file=sys.stderr
         )
+        sys.exit(1)
+    if not parsed.netloc:
+        print("ERROR: --host must include a hostname.", file=sys.stderr)
+        sys.exit(1)
+    if parsed.username or parsed.password:
+        print("ERROR: --host must not include username or password information.", file=sys.stderr)
+        sys.exit(1)
+    try:
+        port = parsed.port
+    except ValueError:
+        print("ERROR: --host contains an invalid port.", file=sys.stderr)
+        sys.exit(1)
+    if port not in (None, 443):
+        print("ERROR: --host must use the standard HTTPS port because glab --hostname does not accept ports.", file=sys.stderr)
+        sys.exit(1)
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        print("ERROR: --host must be only an HTTPS scheme and host, with no path, query, or fragment.", file=sys.stderr)
         sys.exit(1)
     return host.rstrip("/")
 
@@ -214,32 +183,128 @@ def load_batch_file(path):
     return validated
 
 
-# ── GitLab API helpers ────────────────────────────────────────────────────────
+# ── glab API helpers ──────────────────────────────────────────────────────────
 
-def _make_ssl_context():
-    """Return a strict SSL context (system CA bundle, no hostname bypass)."""
-    ctx = ssl.create_default_context()
-    return ctx
+class GlabApiError(RuntimeError):
+    """Raised when a glab api call fails."""
 
 
-def _api_get(token, url):
+def get_hostname(host):
+    """Return the hostname that glab should use for an already-validated host URL."""
+    parsed = urllib.parse.urlparse(host)
+    return parsed.hostname or "gitlab.com"
+
+
+def sanitize_glab_error(text, limit=500):
+    """Bound and redact glab stderr/stdout before showing it to a user."""
+    text = text or ""
+    text = re.sub(r'\x1b\][^\x07]*(?:\x07|\x1b\\)', '', text)
+    text = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', text)
+    text = ''.join(
+        char for char in text
+        if char in "\n\t" or 0x20 <= ord(char) < 0x7f or ord(char) >= 0xa0
+    )
+    text = re.sub(
+        r'(?im)^(\s*>?\s*)(Authorization|PRIVATE-TOKEN|JOB-TOKEN|OAUTH-TOKEN)\s*:.*$',
+        lambda match: "%s%s: [REDACTED]" % (match.group(1), match.group(2)),
+        text,
+    )
+    text = re.sub(r'glpat-[A-Za-z0-9_\-]+', 'glpat-[REDACTED]', text)
+    text = re.sub(r'(?i)(PRIVATE-TOKEN|Authorization|Bearer|token)([=: ]+)(\S+)', r'\1\2[REDACTED]', text)
+    text = text.replace("\r", "\n").strip()
+    if len(text) > limit:
+        text = text[:limit] + "...(truncated)"
+    return text
+
+
+def parse_included_response(output):
+    """Parse `glab api --include` output into (JSON body, response headers)."""
+    normalized = output.replace("\r\n", "\n")
+    header_text, sep, body_text = normalized.rpartition("\n\n")
+    if not sep:
+        raise GlabApiError("glab api response did not include HTTP headers")
+
+    header_blocks = [block for block in header_text.split("\n\n") if block.strip()]
+    active_headers = header_blocks[-1].splitlines() if header_blocks else []
+    headers = {}
+    for line in active_headers:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+    return json.loads(body_text), headers
+
+
+def run_glab_api(host, endpoint, method=None, payload=None, include_headers=False):
+    """Run an authenticated GitLab API call through glab without reading credentials."""
+    args = ["glab", "api", "--hostname", get_hostname(host)]
+    if include_headers:
+        args.append("--include")
+    if method:
+        args.extend(["--method", method])
+    input_text = None
+    if payload is not None:
+        args.extend(["--header", "Content-Type: application/json", "--input", "-"])
+        input_text = json.dumps(payload)
+    args.append(endpoint)
+
+    try:
+        result = subprocess.run(
+            args,
+            input=input_text,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        raise GlabApiError("glab executable not found. Install glab and run: glab auth login")
+    except subprocess.TimeoutExpired:
+        raise GlabApiError("glab api timed out")
+
+    if result.returncode != 0:
+        detail = sanitize_glab_error(result.stderr or result.stdout)
+        if detail:
+            raise GlabApiError("glab api failed: %s" % detail)
+        raise GlabApiError("glab api failed with exit code %s" % result.returncode)
+
+    if include_headers:
+        try:
+            return parse_included_response(result.stdout)
+        except (json.JSONDecodeError, GlabApiError) as e:
+            raise GlabApiError("Could not parse glab api response: %s" % e)
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise GlabApiError("Could not parse glab api JSON response: %s" % e)
+
+
+def _api_get(host, endpoint):
     """Authenticated GET request, returns parsed JSON."""
-    req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": token})
-    with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-        return json.loads(resp.read())
+    return run_glab_api(host, endpoint)
 
 
-def _api_get_with_headers(token, url):
+def _api_get_with_headers(host, endpoint):
     """Authenticated GET request, returns (parsed_json, headers)."""
-    req = urllib.request.Request(url, headers={"PRIVATE-TOKEN": token})
-    with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-        return json.loads(resp.read()), resp.headers
+    return run_glab_api(host, endpoint, include_headers=True)
 
 
-def get_mr_versions(token, host, project_id, mr_iid):
+def verify_glab_identity(host):
+    """Verify and display the selected GitLab host/account before write workflow calls."""
+    user = _api_get(host, "/user")
+    username = (user.get("username") or "").strip() if isinstance(user, dict) else ""
+    if not username:
+        raise GlabApiError("glab /user response did not include a non-empty username")
+    print(f"GitLab host: {get_hostname(host)}")
+    print(f"GitLab user: {username}")
+    return username
+
+
+def get_mr_versions(host, project_id, mr_iid):
     """Fetch current HEAD/START/BASE SHAs for an MR."""
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/versions"
-    versions = _api_get(token, url)
+    endpoint = f"/projects/{project_id}/merge_requests/{mr_iid}/versions"
+    versions = _api_get(host, endpoint)
     if not versions:
         raise ValueError(f"No versions found for MR !{mr_iid}")
     latest = versions[0]
@@ -250,20 +315,20 @@ def get_mr_versions(token, host, project_id, mr_iid):
     }
 
 
-def get_mr_diffs(token, host, project_id, mr_iid):
+def get_mr_diffs(host, project_id, mr_iid):
     """Fetch all MR diffs so we can compute line_code anchors when GitLab requires them."""
     diffs = []
     page = 1
 
     while True:
-        url = (
-            f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/diffs"
+        endpoint = (
+            f"/projects/{project_id}/merge_requests/{mr_iid}/diffs"
             f"?per_page=100&page={page}"
         )
-        page_diffs, headers = _api_get_with_headers(token, url)
+        page_diffs, headers = _api_get_with_headers(host, endpoint)
         diffs.extend(page_diffs)
 
-        next_page = (headers.get("X-Next-Page") or "").strip()
+        next_page = (headers.get("x-next-page") or "").strip()
         if not next_page:
             break
         page = int(next_page)
@@ -386,43 +451,26 @@ def build_line_range_payload(shas, diff_entry, file_path, body, anchor):
     }
 
 
-def post_discussion(token, url, payload):
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={
-            "PRIVATE-TOKEN": token,
-            "Content-Type":  "application/json",
-        },
-        method="POST"
-    )
-
-    try:
-        with urllib.request.urlopen(req, context=_make_ssl_context()) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        error_body = e.read().decode(errors="replace")
-        raise RuntimeError(f"HTTP {e.code}: {error_body[:500]}")
+def post_discussion(host, project_id, mr_iid, payload):
+    endpoint = f"/projects/{project_id}/merge_requests/{mr_iid}/discussions"
+    return run_glab_api(host, endpoint, method="POST", payload=payload)
 
 
 def is_line_code_validation_error(error_text):
     return "line_code" in error_text and "valid" in error_text.lower()
 
 
-def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path, line_number, body):
+def post_inline_comment(host, project_id, mr_iid, shas, diffs, file_path, line_number, body):
     """
     Post a single inline comment on a MR diff using a JSON body.
     First try the simple new_line payload; if GitLab rejects it with a line_code
     validation error, compute the diff anchor and retry with position.line_range.
     Returns (disc_id, is_inline, used_line_code_retry) tuple.
     """
-    url = f"{host}/api/v4/projects/{project_id}/merge_requests/{mr_iid}/discussions"
-
     diff_entry = find_file_diff(diffs, file_path)
 
     try:
-        r = post_discussion(token, url, build_inline_payload(shas, diff_entry, file_path, line_number, body))
+        r = post_discussion(host, project_id, mr_iid, build_inline_payload(shas, diff_entry, file_path, line_number, body))
         used_line_code_retry = False
     except Exception as e:
         error_text = str(e)
@@ -431,7 +479,7 @@ def post_inline_comment(token, host, project_id, mr_iid, shas, diffs, file_path,
 
         anchor = compute_diff_anchor(diff_entry.get("diff", ""), line_number)
         retry_payload = build_line_range_payload(shas, diff_entry, file_path, body, anchor)
-        r = post_discussion(token, url, retry_payload)
+        r = post_discussion(host, project_id, mr_iid, retry_payload)
         used_line_code_retry = True
 
     note = r.get("notes", [{}])[0]
@@ -477,13 +525,16 @@ def main():
             "body": validate_body(args.body),
         }]
 
-    # Fetch token after validation (avoids unnecessary credential access on bad input)
-    token = get_token(host)
+    try:
+        verify_glab_identity(host)
+    except Exception as e:
+        print(f"ERROR: Could not verify glab identity: {e}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Fetching current HEAD SHAs for MR !{args.mr}...")
     try:
-        shas = get_mr_versions(token, host, project_id, args.mr)
-        diffs = get_mr_diffs(token, host, project_id, args.mr)
+        shas = get_mr_versions(host, project_id, args.mr)
+        diffs = get_mr_diffs(host, project_id, args.mr)
     except Exception as e:
         print(f"ERROR: Could not fetch MR metadata/diffs: {e}", file=sys.stderr)
         sys.exit(1)
@@ -496,11 +547,11 @@ def main():
         body        = c["body"]
 
         print(f"\nPosting: {file_path}:{line_number}")
-        print(f"  Body: {body[:80]}{'...' if len(body) > 80 else ''}")
+        print(f"  Body length: {len(body)} characters")
 
         try:
             disc_id, is_inline, used_line_code_retry = post_inline_comment(
-                token, host, project_id, args.mr, shas, diffs, file_path, line_number, body
+                host, project_id, args.mr, shas, diffs, file_path, line_number, body
             )
             if is_inline and used_line_code_retry:
                 status = "✅ INLINE (line_code retry)"

--- a/scripts/post-inline-comment.py
+++ b/scripts/post-inline-comment.py
@@ -60,13 +60,19 @@ import re
 import subprocess
 import sys
 import urllib.parse
+from typing import Optional
 
 # ── Security constants ────────────────────────────────────────────────────────
 MAX_BODY_LENGTH = 10_000      # GitLab's own limit is ~1MB but we cap for safety
 MAX_BATCH_SIZE  = 100         # prevent runaway API usage
 MAX_BATCH_FILE_BYTES = 1_048_576  # 1 MB batch file limit
-VALID_PROJECT_RE = re.compile(r'^[\w.\-]+(/[\w.\-]+)+$')  # group/project or group/sub/project
-VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control characters
+VALID_PROJECT_RE = re.compile(r'[\w.\-]+(/[\w.\-]+)+')  # group/project or group/sub/project
+VALID_FILE_RE    = re.compile(
+    r'[^\x00-\x1f\x7f-\x9f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]+'
+)  # no terminal or bidirectional control characters
+BIDI_CONTROL_CHARS = frozenset(
+    "\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+)
 
 # ── Input validation ──────────────────────────────────────────────────────────
 
@@ -106,9 +112,9 @@ def validate_host(host):
 
 def validate_project(project):
     """Validate project path format: group/project or group/subgroup/project."""
-    if not VALID_PROJECT_RE.match(project):
+    if not VALID_PROJECT_RE.fullmatch(project):
         print(
-            f"ERROR: --project '{project}' is not a valid GitLab project path.\n"
+            f"ERROR: --project {project!r} is not a valid GitLab project path.\n"
             "  Expected format: 'group/project' or 'group/subgroup/project'",
             file=sys.stderr
         )
@@ -118,7 +124,7 @@ def validate_project(project):
 
 def validate_file_path(file_path):
     """Validate that a file path doesn't contain dangerous characters."""
-    if not file_path or not VALID_FILE_RE.match(file_path):
+    if not file_path or not VALID_FILE_RE.fullmatch(file_path):
         print(f"ERROR: Invalid file path: {repr(file_path)}", file=sys.stderr)
         sys.exit(1)
     return file_path
@@ -160,7 +166,10 @@ def load_batch_file(path):
         with open(path) as f:
             comments = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
-        print(f"ERROR: Could not load batch file '{path}': {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not load batch file {path!r}: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     if not isinstance(comments, list):
@@ -199,15 +208,28 @@ def get_hostname(host):
     return parsed.hostname or "gitlab.com"
 
 
-def sanitize_glab_error(text, limit=500):
-    """Bound and redact glab stderr/stdout before showing it to a user."""
-    text = text or ""
+def sanitize_terminal(text, limit: Optional[int] = 500, multiline=False):
+    """Remove terminal controls from untrusted text before displaying it."""
+    text = str(text or "").replace("\r\n", "\n").replace("\r", "\n")
     text = re.sub(r'\x1b\][^\x07]*(?:\x07|\x1b\\)', '', text)
     text = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', text)
     text = ''.join(
         char for char in text
-        if char in "\n\t" or 0x20 <= ord(char) < 0x7f or ord(char) >= 0xa0
+        if char not in BIDI_CONTROL_CHARS and (
+            (multiline and char in "\n\t")
+            or 0x20 <= ord(char) < 0x7f
+            or ord(char) >= 0xa0
+        )
     )
+    text = text.strip()
+    if limit is not None and len(text) > limit:
+        text = text[:limit] + "...(truncated)"
+    return text
+
+
+def sanitize_glab_error(text, limit=500):
+    """Bound and redact glab stderr/stdout before showing it to a user."""
+    text = sanitize_terminal(text, limit=None, multiline=True)
     text = re.sub(
         r'(?im)^(\s*>?\s*)(Authorization|PRIVATE-TOKEN|JOB-TOKEN|OAUTH-TOKEN)\s*:.*$',
         lambda match: "%s%s: [REDACTED]" % (match.group(1), match.group(2)),
@@ -215,7 +237,6 @@ def sanitize_glab_error(text, limit=500):
     )
     text = re.sub(r'glpat-[A-Za-z0-9_\-]+', 'glpat-[REDACTED]', text)
     text = re.sub(r'(?i)(PRIVATE-TOKEN|Authorization|Bearer|token)([=: ]+)(\S+)', r'\1\2[REDACTED]', text)
-    text = text.replace("\r", "\n").strip()
     if len(text) > limit:
         text = text[:limit] + "...(truncated)"
     return text
@@ -224,12 +245,17 @@ def sanitize_glab_error(text, limit=500):
 def parse_included_response(output):
     """Parse `glab api --include` output into (JSON body, response headers)."""
     normalized = output.replace("\r\n", "\n")
-    header_text, sep, body_text = normalized.rpartition("\n\n")
+    status_lines = list(re.finditer(r'(?m)^HTTP/\S+\s+\d{3}(?:\s+[^\n]*)?$', normalized))
+    if not status_lines:
+        raise GlabApiError("glab api response did not include an HTTP status line")
+    # Start at the final response's status line, then split at that header block's
+    # first blank line. This keeps blank lines in pretty-printed JSON bodies intact.
+    final_response = normalized[status_lines[-1].start():]
+    header_text, sep, body_text = final_response.partition("\n\n")
     if not sep:
         raise GlabApiError("glab api response did not include HTTP headers")
 
-    header_blocks = [block for block in header_text.split("\n\n") if block.strip()]
-    active_headers = header_blocks[-1].splitlines() if header_blocks else []
+    active_headers = header_text.splitlines()
     headers = {}
     for line in active_headers:
         if ":" not in line:
@@ -302,10 +328,10 @@ def _api_get_with_headers(host, endpoint):
 def verify_glab_identity(host):
     """Verify and display the selected GitLab host/account before write workflow calls."""
     user = _api_get(host, "/user")
-    username = (user.get("username") or "").strip() if isinstance(user, dict) else ""
+    username = sanitize_terminal(user.get("username")) if isinstance(user, dict) else ""
     if not username:
         raise GlabApiError("glab /user response did not include a non-empty username")
-    print(f"GitLab host: {get_hostname(host)}")
+    print(f"GitLab host: {sanitize_terminal(get_hostname(host))}")
     print(f"GitLab user: {username}")
     return username
 
@@ -537,7 +563,10 @@ def main():
     try:
         verify_glab_identity(host)
     except Exception as e:
-        print(f"ERROR: Could not verify glab identity: {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not verify glab identity: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     print(f"Fetching current HEAD SHAs for MR !{args.mr}...")
@@ -545,9 +574,12 @@ def main():
         shas = get_mr_versions(host, project_id, args.mr)
         diffs = get_mr_diffs(host, project_id, args.mr)
     except Exception as e:
-        print(f"ERROR: Could not fetch MR metadata/diffs: {e}", file=sys.stderr)
+        print(
+            f"ERROR: Could not fetch MR metadata/diffs: {sanitize_glab_error(str(e))}",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    print(f"  head_sha: {shas['head_sha'][:12]}...")
+    print(f"  head_sha: {sanitize_terminal(shas.get('head_sha'))[:12]}...")
 
     results = []
     for c in comments:
@@ -568,7 +600,7 @@ def main():
                 status = "✅ INLINE"
             else:
                 status = "⚠️  GENERAL (position rejected — check line number)"
-            print(f"  {status} | disc_id: {disc_id}")
+            print(f"  {status} | disc_id: {sanitize_terminal(disc_id)}")
             results.append({
                 "disc_id":              disc_id,
                 "is_inline":            is_inline,
@@ -577,7 +609,7 @@ def main():
                 "line":                 line_number,
             })
         except Exception as e:
-            print(f"  ❌ FAILED: {e}", file=sys.stderr)
+            print(f"  ❌ FAILED: {sanitize_glab_error(str(e))}", file=sys.stderr)
             results.append({"error": str(e), "file": file_path, "line": line_number})
 
     # Summary

--- a/scripts/post-inline-comment.py
+++ b/scripts/post-inline-comment.py
@@ -72,7 +72,11 @@ VALID_FILE_RE    = re.compile(r'^[^\x00-\x1f\x7f]+$')      # no terminal control
 
 def validate_host(host):
     """Enforce an unambiguous HTTPS host URL before invoking glab."""
-    parsed = urllib.parse.urlparse(host)
+    try:
+        parsed = urllib.parse.urlparse(host)
+    except ValueError:
+        print("ERROR: --host is not a valid URL.", file=sys.stderr)
+        sys.exit(1)
     if parsed.scheme != "https":
         print(
             f"ERROR: --host must use HTTPS (got '{parsed.scheme}://').\n"
@@ -263,7 +267,12 @@ def run_glab_api(host, endpoint, method=None, payload=None, include_headers=Fals
         raise GlabApiError("glab api timed out")
 
     if result.returncode != 0:
-        detail = sanitize_glab_error(result.stderr or result.stdout)
+        # glab writes structured API errors to stdout but may also write a generic
+        # `glab: HTTP 400` status to stderr. Keep stdout first so callers can
+        # inspect validation details such as `line_code` and apply safe retries.
+        detail = sanitize_glab_error("\n".join(
+            part for part in (result.stdout, result.stderr) if part
+        ))
         if detail:
             raise GlabApiError("glab api failed: %s" % detail)
         raise GlabApiError("glab api failed with exit code %s" % result.returncode)

--- a/tests/test_post_inline_comment_glab_api.py
+++ b/tests/test_post_inline_comment_glab_api.py
@@ -90,6 +90,20 @@ class GlabApiTests(unittest.TestCase):
             with self.assertRaisesRegex(self.helper.GlabApiError, "username"):
                 self.helper.verify_glab_identity("https://gitlab.example.com")
 
+    def test_verify_glab_identity_sanitizes_api_control_sequences(self):
+        """Catches API-controlled terminal escapes reaching identity progress output."""
+        fake_run = FakeRun([(0, json.dumps({"username": "bob\x1b[2J\x1b[Hpwned\u202e"}), "")])
+
+        with mock.patch.object(self.helper.subprocess, "run", fake_run), \
+                mock.patch("sys.stdout") as stdout:
+            username = self.helper.verify_glab_identity("https://gitlab.example.com")
+
+        output = "".join(c.args[0] for c in stdout.write.call_args_list)
+        self.assertEqual(username, "bobpwned")
+        self.assertIn("GitLab user: bobpwned", output)
+        self.assertNotIn("\x1b", output)
+        self.assertNotIn("\u202e", output)
+
     def test_host_validation_rejects_ambiguous_urls_and_unsupported_ports(self):
         """Catches passing ports that real glab --hostname rejects or accepting ambiguous URLs."""
         host = self.helper.validate_host("https://gitlab.example.com:443")
@@ -175,12 +189,65 @@ class GlabApiTests(unittest.TestCase):
         self.assertNotIn("oauth-secret", redacted)
         self.assertIn("message: line_code must be valid", redacted)
 
+    def test_glab_error_normalizes_carriage_returns_before_filtering(self):
+        """Catches dead or reordered CR normalization in multiline diagnostics."""
+        sanitized = self.helper.sanitize_glab_error("first\rsecond\r\nthird")
+        self.assertEqual(sanitized, "first\nsecond\nthird")
+
     def test_file_path_validation_rejects_terminal_control_characters(self):
         """Catches file paths that could inject terminal output when progress is printed."""
-        for path in ["src/unsafe\x1b[31m.py", "src/unsafe\tname.py", "src/unsafe\x7fname.py"]:
+        for path in [
+            "src/unsafe\x1b[31m.py",
+            "src/unsafe\tname.py",
+            "src/unsafe\n",
+            "src/unsafe\x7fname.py",
+            "src/unsafe\x9bname.py",
+            "src/unsafe\u202ename.py",
+        ]:
             with self.subTest(path=path), mock.patch("sys.stderr"):
                 with self.assertRaises(SystemExit):
                     self.helper.validate_file_path(path)
+
+    def test_user_controlled_validation_errors_do_not_emit_terminal_controls(self):
+        """Catches invalid project or batch paths reaching stderr with raw ANSI sequences."""
+        cases = [
+            [
+                "--project", "bad\x1b[2Jproject",
+                "--mr", "1",
+                "--file", "a.py",
+                "--line", "1",
+                "--body", "x",
+            ],
+            [
+                "--project", "group/project",
+                "--mr", "1",
+                "--batch", "missing\x1b[2J.json",
+            ],
+            [
+                "--project", "group/project\n",
+                "--mr", "1",
+                "--file", "a.py",
+                "--line", "1",
+                "--body", "x",
+            ],
+        ]
+        for args in cases:
+            with self.subTest(args=args):
+                result = subprocess.run(
+                    [sys.executable, str(SCRIPT)] + args,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn("\x1b", result.stderr)
+
+    def test_included_response_keeps_blank_lines_in_pretty_json_body(self):
+        """Catches splitting --include output at the body's final blank line."""
+        output = "HTTP/2 200 OK\r\nX-Next-Page: \r\n\r\n{\n\n  \"items\": [1, 2]\n}\n"
+        body, headers = self.helper.parse_included_response(output)
+        self.assertEqual(body, {"items": [1, 2]})
+        self.assertEqual(headers.get("x-next-page"), "")
 
     def test_non_inline_response_is_reported(self):
         """Catches treating a general discussion response as a valid inline note."""
@@ -237,12 +304,12 @@ from pathlib import Path
 
 endpoint = sys.argv[-1]
 if endpoint == "/user":
-    print(json.dumps({"username": "reviewer"}))
+    print(json.dumps({"username": "reviewer\\x1b[2Jpwned"}))
 elif endpoint.endswith("/versions"):
     print(json.dumps([{
         "base_commit_sha": "base",
         "start_commit_sha": "start",
-        "head_commit_sha": "head"
+        "head_commit_sha": "head\\x1b[2Jpwned"
     }]))
 elif "/diffs?" in endpoint:
     body = [{
@@ -267,7 +334,7 @@ elif endpoint.endswith("/discussions"):
         print("missing line_range retry", file=sys.stderr)
         sys.exit(2)
     print(json.dumps({
-        "id": "disc-inline",
+        "id": "disc-inline\\x1b[2Jpwned",
         "notes": [{"position": {"line_range": payload["position"]["line_range"]}}]
     }))
 else:
@@ -300,12 +367,25 @@ else:
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(post_count, "2")
         self.assertIn("INLINE (line_code retry)", result.stdout)
-        self.assertIn('Discussion IDs: ["disc-inline"]', result.stdout)
+        self.assertIn("GitLab user: reviewerpwned", result.stdout)
+        self.assertIn("head_sha: headpwned", result.stdout)
+        self.assertIn("disc_id: disc-inlinepwned", result.stdout)
+        self.assertIn("Discussion IDs:", result.stdout)
+        self.assertNotIn("\x1b", result.stdout)
         self.assertNotIn("Review comment", result.stdout)
         self.assertNotIn("token", result.stdout.lower())
 
 
 class ArtifactRegressionTests(unittest.TestCase):
+    def test_post_inline_comment_helper_mirrors_are_byte_identical(self):
+        """Locks the standalone and packaged helper copies together."""
+        helper_paths = [
+            ROOT / "scripts" / "post-inline-comment.py",
+            ROOT / "glab-mr" / "scripts" / "post-inline-comment.py",
+            ROOT / "gitlab-cli-skills" / "scripts" / "post-inline-comment.py",
+        ]
+        self.assertEqual(len({path.read_bytes() for path in helper_paths}), 1)
+
     def test_source_and_merged_artifact_do_not_extract_plaintext_glab_tokens(self):
         """Catches reintroducing the reported glab config token extraction snippet."""
         forbidden_patterns = [
@@ -375,6 +455,25 @@ class ShellWrapperTests(unittest.TestCase):
         args = result.stdout.splitlines()
         self.assertEqual(args[args.index("--host") + 1], "https://gitlab.example.com")
         self.assertNotIn("token", result.stdout.lower())
+
+    def test_wrapper_requires_exactly_five_arguments(self):
+        result = subprocess.run(
+            [
+                "bash",
+                str(ROOT / "scripts" / "add-inline-comment.sh"),
+                "group/project",
+                "42",
+                "src/main.py",
+                "7",
+                "Review comment",
+                "unexpected extra argument",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Usage:", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_post_inline_comment_glab_api.py
+++ b/tests/test_post_inline_comment_glab_api.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import unittest
 import zipfile
@@ -100,6 +101,7 @@ class GlabApiTests(unittest.TestCase):
             "https://gitlab.example.com/?q=1",
             "https://gitlab.example.com/#frag",
             "https://gitlab.example.com:8443",
+            "https://[malformed",
         ]
         for bad_host in bad_hosts:
             with self.subTest(bad_host=bad_host):
@@ -132,6 +134,27 @@ class GlabApiTests(unittest.TestCase):
         self.assertEqual(json.loads(kwargs["input"]), payload)
         self.assertNotIn("PRIVATE-TOKEN", " ".join(args))
         self.assertNotIn("config get token", " ".join(args))
+
+    def test_glab_error_keeps_stdout_validation_details_when_stderr_is_present(self):
+        """Preserves structured line_code details that glab writes to stdout on HTTP errors."""
+        fake_run = FakeRun([(
+            1,
+            json.dumps({"message": {"position": ["line_code must be a valid line code"]}}),
+            "glab: HTTP 400\n",
+        )])
+
+        with mock.patch.object(self.helper.subprocess, "run", fake_run):
+            with self.assertRaises(self.helper.GlabApiError) as raised:
+                self.helper.run_glab_api(
+                    "https://gitlab.example.com",
+                    "/projects/group%2Fproject/merge_requests/7/discussions",
+                    method="POST",
+                    payload={"body": "review", "position": {}},
+                )
+
+        message = str(raised.exception)
+        self.assertIn("line_code must be a valid line code", message)
+        self.assertIn("glab: HTTP 400", message)
 
     def test_glab_errors_redact_sensitive_header_lines(self):
         """Catches leaking authorization material from glab stderr."""
@@ -197,6 +220,89 @@ class GlabApiTests(unittest.TestCase):
         retry_payload = calls[1][3]
         self.assertIn("line_range", retry_payload["position"])
         self.assertEqual(calls[1][:3], ("https://gitlab.example.com", "group%2Fproject", 7))
+
+
+class FakeGlabEndToEndTests(unittest.TestCase):
+    def test_cli_retries_line_code_when_glab_splits_error_across_stdout_and_stderr(self):
+        """Exercises the real subprocess boundary from identity preflight through retry success."""
+        with tempfile.TemporaryDirectory() as td:
+            temp_dir = Path(td)
+            fake_glab = temp_dir / "glab"
+            state_file = temp_dir / "post-count"
+            fake_glab.write_text("""#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+endpoint = sys.argv[-1]
+if endpoint == "/user":
+    print(json.dumps({"username": "reviewer"}))
+elif endpoint.endswith("/versions"):
+    print(json.dumps([{
+        "base_commit_sha": "base",
+        "start_commit_sha": "start",
+        "head_commit_sha": "head"
+    }]))
+elif "/diffs?" in endpoint:
+    body = [{
+        "old_path": "src/a.py",
+        "new_path": "src/a.py",
+        "diff": "@@ -1,0 +10,1 @@\\n+target"
+    }]
+    sys.stdout.write("HTTP/2 200 OK\\r\\nX-Next-Page: \\r\\n\\r\\n" + json.dumps(body))
+elif endpoint.endswith("/discussions"):
+    payload = json.load(sys.stdin)
+    state = Path(os.environ["FAKE_GLAB_STATE"])
+    count = int(state.read_text()) if state.exists() else 0
+    count += 1
+    state.write_text(str(count))
+    if count == 1:
+        print(json.dumps({
+            "message": {"position": ["line_code must be a valid line code"]}
+        }))
+        print("glab: HTTP 400", file=sys.stderr)
+        sys.exit(1)
+    if "line_range" not in payload.get("position", {}):
+        print("missing line_range retry", file=sys.stderr)
+        sys.exit(2)
+    print(json.dumps({
+        "id": "disc-inline",
+        "notes": [{"position": {"line_range": payload["position"]["line_range"]}}]
+    }))
+else:
+    print("unexpected endpoint: " + endpoint, file=sys.stderr)
+    sys.exit(3)
+""")
+            fake_glab.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = td + os.pathsep + env.get("PATH", "")
+            env["FAKE_GLAB_STATE"] = str(state_file)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--host", "https://gitlab.example.com",
+                    "--project", "group/project",
+                    "--mr", "7",
+                    "--file", "src/a.py",
+                    "--line", "10",
+                    "--body", "Review comment",
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+            post_count = state_file.read_text() if state_file.exists() else ""
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(post_count, "2")
+        self.assertIn("INLINE (line_code retry)", result.stdout)
+        self.assertIn('Discussion IDs: ["disc-inline"]', result.stdout)
+        self.assertNotIn("Review comment", result.stdout)
+        self.assertNotIn("token", result.stdout.lower())
 
 
 class ArtifactRegressionTests(unittest.TestCase):

--- a/tests/test_post_inline_comment_glab_api.py
+++ b/tests/test_post_inline_comment_glab_api.py
@@ -1,0 +1,275 @@
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "post-inline-comment.py"
+
+
+def load_helper():
+    spec = importlib.util.spec_from_file_location("post_inline_comment", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeRun:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append((args, kwargs))
+        if not self.responses:
+            raise AssertionError("unexpected subprocess.run call: %r" % (args,))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return subprocess.CompletedProcess(args, response[0], response[1], response[2])
+
+
+def included_response(body, headers=None, status="HTTP/2 200 OK"):
+    header_lines = [status]
+    for name, value in (headers or {}).items():
+        header_lines.append("%s: %s" % (name, value))
+    return "\r\n".join(header_lines) + "\r\n\r\n" + json.dumps(body)
+
+
+class GlabApiTests(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+
+    def test_get_paginates_with_include_headers_and_hostname(self):
+        """Catches dropping X-Next-Page handling or omitting --hostname."""
+        fake_run = FakeRun([
+            (0, included_response([{"new_path": "a.py"}], {"x-next-page": "2"}), ""),
+            (0, included_response([{"new_path": "b.py"}], {"X-Next-Page": ""}), ""),
+        ])
+
+        with mock.patch.object(self.helper.subprocess, "run", fake_run):
+            diffs = self.helper.get_mr_diffs("https://gitlab.example.com", "group%2Fproject", 7)
+
+        self.assertEqual([d["new_path"] for d in diffs], ["a.py", "b.py"])
+        self.assertEqual(len(fake_run.calls), 2)
+        first_args, first_kwargs = fake_run.calls[0]
+        second_args, _ = fake_run.calls[1]
+        self.assertEqual(first_args[:4], ["glab", "api", "--hostname", "gitlab.example.com"])
+        self.assertIn("--include", first_args)
+        self.assertIn("/projects/group%2Fproject/merge_requests/7/diffs?per_page=100&page=1", first_args)
+        self.assertIn("/projects/group%2Fproject/merge_requests/7/diffs?per_page=100&page=2", second_args)
+        self.assertFalse(first_kwargs.get("shell", False))
+
+    def test_verify_glab_identity_prints_selected_host_and_username(self):
+        """Catches writes happening without a visible account preflight."""
+        fake_run = FakeRun([(0, json.dumps({"username": "alice", "name": "Alice"}), "")])
+
+        with mock.patch.object(self.helper.subprocess, "run", fake_run), \
+                mock.patch("sys.stdout") as stdout:
+            username = self.helper.verify_glab_identity("https://gitlab.example.com:443")
+
+        self.assertEqual(username, "alice")
+        args, _ = fake_run.calls[0]
+        self.assertEqual(args, ["glab", "api", "--hostname", "gitlab.example.com", "/user"])
+        self.assertIn("GitLab host: gitlab.example.com", "".join(c.args[0] for c in stdout.write.call_args_list))
+        self.assertIn("GitLab user: alice", "".join(c.args[0] for c in stdout.write.call_args_list))
+
+    def test_verify_glab_identity_rejects_empty_username(self):
+        """Catches accepting an ambiguous authenticated account before writes."""
+        fake_run = FakeRun([(0, json.dumps({"username": ""}), "")])
+
+        with mock.patch.object(self.helper.subprocess, "run", fake_run):
+            with self.assertRaisesRegex(self.helper.GlabApiError, "username"):
+                self.helper.verify_glab_identity("https://gitlab.example.com")
+
+    def test_host_validation_rejects_ambiguous_urls_and_unsupported_ports(self):
+        """Catches passing ports that real glab --hostname rejects or accepting ambiguous URLs."""
+        host = self.helper.validate_host("https://gitlab.example.com:443")
+        self.assertEqual(self.helper.get_hostname(host), "gitlab.example.com")
+
+        bad_hosts = [
+            "https://user@gitlab.example.com",
+            "https://gitlab.example.com/path",
+            "https://gitlab.example.com/?q=1",
+            "https://gitlab.example.com/#frag",
+            "https://gitlab.example.com:8443",
+        ]
+        for bad_host in bad_hosts:
+            with self.subTest(bad_host=bad_host):
+                with mock.patch("sys.stderr"):
+                    with self.assertRaises(SystemExit):
+                        self.helper.validate_host(bad_host)
+
+    def test_post_sends_literal_json_on_stdin_with_input_dash_and_hostname(self):
+        """Catches rebuilding POSTs as form fields or direct token-auth HTTP."""
+        payload = {
+            "body": "please fix",
+            "position": {"position_type": "text", "new_path": "a.py", "new_line": 3},
+        }
+        response = {"id": "disc1", "notes": [{"position": {"new_line": 3}}]}
+        fake_run = FakeRun([(0, json.dumps(response), "")])
+
+        with mock.patch.object(self.helper.subprocess, "run", fake_run):
+            result = self.helper.post_discussion(
+                "https://gitlab.example.com", "group%2Fproject", 7, payload
+            )
+
+        self.assertEqual(result, response)
+        args, kwargs = fake_run.calls[0]
+        self.assertEqual(args[:4], ["glab", "api", "--hostname", "gitlab.example.com"])
+        self.assertIn("--input", args)
+        self.assertEqual(args[args.index("--input") + 1], "-")
+        self.assertIn("--method", args)
+        self.assertEqual(args[args.index("--method") + 1], "POST")
+        self.assertIn("/projects/group%2Fproject/merge_requests/7/discussions", args)
+        self.assertEqual(json.loads(kwargs["input"]), payload)
+        self.assertNotIn("PRIVATE-TOKEN", " ".join(args))
+        self.assertNotIn("config get token", " ".join(args))
+
+    def test_glab_errors_redact_sensitive_header_lines(self):
+        """Catches leaking authorization material from glab stderr."""
+        raw = "\n".join([
+            "\x1b[31m> Authorization: Bearer bearer-secret\x1b[0m",
+            "PRIVATE-TOKEN: glpat-secret",
+            "JOB-TOKEN: ci-secret",
+            "OAUTH-TOKEN: oauth-secret",
+            "message: line_code must be valid",
+        ])
+
+        redacted = self.helper.sanitize_glab_error(raw)
+
+        self.assertNotIn("bearer-secret", redacted)
+        self.assertNotIn("\x1b", redacted)
+        self.assertNotIn("glpat-secret", redacted)
+        self.assertNotIn("ci-secret", redacted)
+        self.assertNotIn("oauth-secret", redacted)
+        self.assertIn("message: line_code must be valid", redacted)
+
+    def test_file_path_validation_rejects_terminal_control_characters(self):
+        """Catches file paths that could inject terminal output when progress is printed."""
+        for path in ["src/unsafe\x1b[31m.py", "src/unsafe\tname.py", "src/unsafe\x7fname.py"]:
+            with self.subTest(path=path), mock.patch("sys.stderr"):
+                with self.assertRaises(SystemExit):
+                    self.helper.validate_file_path(path)
+
+    def test_non_inline_response_is_reported(self):
+        """Catches treating a general discussion response as a valid inline note."""
+        shas = {"base_sha": "base", "start_sha": "start", "head_sha": "head"}
+        diffs = [{"old_path": "a.py", "new_path": "a.py", "diff": "@@ -1 +1 @@\n+new"}]
+        response = {"id": "disc-general", "notes": [{"position": None}]}
+
+        with mock.patch.object(self.helper, "post_discussion", return_value=response):
+            disc_id, is_inline, used_retry = self.helper.post_inline_comment(
+                "https://gitlab.example.com", "group%2Fproject", 7, shas, diffs, "a.py", 1, "body"
+            )
+
+        self.assertEqual(disc_id, "disc-general")
+        self.assertFalse(is_inline)
+        self.assertFalse(used_retry)
+
+    def test_line_code_retry_uses_same_glab_post_path(self):
+        """Catches losing the fallback that retries with position.line_range."""
+        shas = {"base_sha": "base", "start_sha": "start", "head_sha": "head"}
+        diffs = [{"old_path": "a.py", "new_path": "a.py", "diff": "@@ -1 +10 @@\n+target"}]
+        calls = []
+
+        def fake_post(host, project_id, mr_iid, payload):
+            calls.append((host, project_id, mr_iid, payload))
+            if len(calls) == 1:
+                raise self.helper.GlabApiError("glab api failed: line_code must be a valid line code")
+            return {"id": "disc-inline", "notes": [{"position": {"line_range": {}}}]}
+
+        with mock.patch.object(self.helper, "post_discussion", side_effect=fake_post):
+            disc_id, is_inline, used_retry = self.helper.post_inline_comment(
+                "https://gitlab.example.com", "group%2Fproject", 7, shas, diffs, "a.py", 10, "body"
+            )
+
+        self.assertEqual(disc_id, "disc-inline")
+        self.assertTrue(is_inline)
+        self.assertTrue(used_retry)
+        retry_payload = calls[1][3]
+        self.assertIn("line_range", retry_payload["position"])
+        self.assertEqual(calls[1][:3], ("https://gitlab.example.com", "group%2Fproject", 7))
+
+
+class ArtifactRegressionTests(unittest.TestCase):
+    def test_source_and_merged_artifact_do_not_extract_plaintext_glab_tokens(self):
+        """Catches reintroducing the reported glab config token extraction snippet."""
+        forbidden_patterns = [
+            re.compile(r'glab\s+config\s+get\s+token'),
+            re.compile(r'["\']glab["\']\s*,\s*["\']config["\']\s*,\s*["\']get["\']\s*,\s*["\']token["\']'),
+            re.compile(r'PRIVATE-TOKEN["\']?\s*:\s*token'),
+            re.compile(r'glab\s+auth\s+token'),
+        ]
+        source_paths = [
+            ROOT / "scripts" / "post-inline-comment.py",
+            ROOT / "scripts" / "add-inline-comment.sh",
+            ROOT / "glab-mr" / "SKILL.md",
+            ROOT / "glab-mr" / "scripts" / "post-inline-comment.py",
+            ROOT / "gitlab-cli-skills" / "scripts" / "post-inline-comment.py",
+            ROOT / "SECURITY.md",
+        ]
+        for path in source_paths:
+            text = path.read_text()
+            for pattern in forbidden_patterns:
+                self.assertIsNone(pattern.search(text), "%s matched %s" % (pattern.pattern, path))
+
+        with tempfile.TemporaryDirectory() as td:
+            output = Path(td) / "claude-skill.zip"
+            result = subprocess.run(
+                ["bash", str(ROOT / "scripts" / "build-claude-skill.sh"), "--output", str(output), "--root", str(ROOT)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with zipfile.ZipFile(output) as zf:
+                skill_entries = [name for name in zf.namelist() if name == "gitlab-cli-skills/SKILL.md"]
+                self.assertEqual(skill_entries, ["gitlab-cli-skills/SKILL.md"])
+                merged = zf.read("gitlab-cli-skills/SKILL.md").decode("utf-8")
+        for pattern in forbidden_patterns:
+            self.assertIsNone(pattern.search(merged), "%s matched merged artifact" % pattern.pattern)
+
+
+class ShellWrapperTests(unittest.TestCase):
+    def test_wrapper_normalizes_a_bare_glab_host_without_exposing_credentials(self):
+        """Keeps the standard bare GITLAB_HOST form compatible with strict URL validation."""
+        with tempfile.TemporaryDirectory() as td:
+            fake_python = Path(td) / "python3"
+            fake_python.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\n')
+            fake_python.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = td + os.pathsep + env.get("PATH", "")
+            env["GITLAB_HOST"] = "gitlab.example.com"
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(ROOT / "scripts" / "add-inline-comment.sh"),
+                    "group/project",
+                    "42",
+                    "src/main.py",
+                    "7",
+                    "Review comment",
+                ],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        args = result.stdout.splitlines()
+        self.assertEqual(args[args.index("--host") + 1], "https://gitlab.example.com")
+        self.assertNotIn("token", result.stdout.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove plaintext GitLab token extraction and manual `PRIVATE-TOKEN` requests from inline-comment documentation and helper paths
- route authenticated GET/POST calls through `glab api`, using literal JSON on stdin for nested discussion positions
- verify the selected host/account before writes, preserve pagination and line-code fallback behavior, and harden terminal output/redaction
- sanitize API-controlled host, username, head SHA, and discussion ID output; reject C1 and bidirectional controls in printed file paths
- robustly parse included HTTP headers without splitting on blank lines inside JSON bodies
- add regression coverage for source files, byte-identical helper mirrors, the exact five-argument compatibility-wrapper contract, and the generated merged skill artifact

## Security impact

The helper no longer reads, copies, prints, or injects stored GitLab credentials. Authentication remains inside `glab`. Raw comment bodies are no longer echoed, control and bidirectional characters are rejected from printed file paths, API-controlled progress values are sanitized, and sensitive/debug header output is bounded and redacted.

## Validation

- `python3 -m unittest discover -s tests -v` — 19 passed
- fake-`glab` end-to-end subprocess test covers identity, versions, paginated diffs, split stdout/stderr HTTP validation details, ANSI injection on API-controlled success values, and successful `line_code` retry
- regression sabotage: the artifact/source regression test fails against `origin/main` on the original `"glab", "config", "get", "token"` helper pattern, then passes on this branch
- all three helper mirrors are byte-identical
- Python compile checks for all three mirrored helpers and Python 3.6 grammar checks for the helpers and test module
- `bash -n scripts/add-inline-comment.sh`
- included-response parser verified with multiple HTTP header blocks and pretty JSON containing blank lines
- extracted documentation example: Bash syntax valid and no unsupported `glab api --jq` flag
- live read-only `glab api --include` response parsing against GitLab.com
- live read-only GraphQL query through `glab api --header 'Content-Type: application/json' --input -`
- `npx --yes skills add . --list` — 48 skills discovered
- `bash scripts/build-claude-skill.sh --output <temporary artifact>`
  - exactly `gitlab-cli-skills/` and `gitlab-cli-skills/SKILL.md`
  - zero token-extraction/manual-header patterns in the merged skill
- `git diff --check`

## Compatibility / risk

- the helper remains compatible with its documented Python 3.6+ runtime
- bare `GITLAB_HOST` values are normalized to HTTPS by the legacy shell wrapper; non-default ports are rejected because `glab api --hostname` does not accept them
- the compatibility wrapper now rejects extra positional arguments so comment text must be passed as one quoted fifth argument, matching its documented contract
- no version bump, release, publication, or real MR comment write is included

Fixes #86
